### PR TITLE
Proxy Support for Tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,8 @@ provisioner:
   roles_path: ../
   require_ansible_repo: true
   ansible_verbose: true
+  http_proxy: <%= ENV['HTTP_PROXY'] %>
+  https_proxy: <%= ENV['HTTPS_PROXY'] %>
 
 platforms:
   - name: ubuntu-14.04


### PR DESCRIPTION
Adds proxy support for tests.  These proxy settings are used within the kitchen docker instances for caching in tests.

Tested that if not specified no impact on tests.

To specify, set HTTP_PROXY and/or HTTPS_PROXY env variable

HTTP_PROXY="http://<host>:<port>" kitchen converge standard-2x-centos-7
