### PR TITLE
No Proxy option for localhost

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ provisioner:
   ansible_verbose: true
   http_proxy: <%= ENV['HTTP_PROXY'] %>
   https_proxy: <%= ENV['HTTPS_PROXY'] %>
+  no_proxy: localhost,127.0.0.1
 
 platforms:
   - name: ubuntu-14.04


### PR DESCRIPTION
Required when using a proxy for kitchen tests. Specifically needed for loading templates which uses a curl localhost command.
