### PR TITLE
Fail if ERROR in stdout when installing plugin

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -22,7 +22,7 @@
   #debug: var=item
   command: "{{es_home}}/bin/plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %} --silent"
   register: plugin_installed
-  failed_when: "'Failed to install' in plugin_installed.stderr"
+  failed_when: "'Failed to install' in plugin_installed.stderr or 'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: es_plugins
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Debian'

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -17,6 +17,7 @@
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"
+    ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
   #debug: var=item


### PR DESCRIPTION
Otherwise many errors (e.g. just wrong plugin name) will be swallowed without plugin being installed successfully ...