### PR TITLE
Custom scripts templates 57

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ controlled by the following parameters:
 * ```es_work_dir``` - defaults to "/tmp/elasticsearch".
 * ```es_plugin_dir``` - defaults to "/usr/share/elasticsearch/plugins".
 
+This role ships with sample scripts and templates located in the [files/scripts/](files/scripts) and [files/templates/](files/templates) directories, respectively. These variables are used with the Ansible [with_fileglob](http://docs.ansible.com/ansible/playbooks_loops.html#id4) loop. When setting the globs, be sure to use an absolute path.
+* ```es_scripts_fileglob``` - defaults to `<role>/files/scripts/`.
+* ```es_templates_fileglob``` - defaults to `<role>/files/templates/`.
+
 ## Notes
 
 * The role assumes the user/group exists on the server.  The elasticsearch packages create the default elasticsearch user.  If this needs to be changed, ensure the user exists.

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -10,4 +10,5 @@
   when: es_config['path.scripts'] is defined
 
 - name: Copy scripts to elasticsearch
-  copy: src=scripts dest={{ es_script_dir }} owner={{ es_user }} group={{ es_group }}
+  copy: src={{ item }} dest={{ es_script_dir }} owner={{ es_user }} group={{ es_group }}
+  with_fileglob: es_scripts_fileglob | default("scripts")

--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: Copy templates to elasticsearch
-  copy: src=templates dest=/etc/elasticsearch/ owner={{ es_user }} group={{ es_group }}
+  copy: src={{ item }} dest=/etc/elasticsearch/ owner={{ es_user }} group={{ es_group }}
+  with_fileglob: es_templates_fileglob | default("templates")
 
 - set_fact: http_port=9200
 


### PR DESCRIPTION
This PR addresses the enhancement described in Issue #57.

It uses the Ansible [with_fileglob](http://docs.ansible.com/ansible/playbooks_loops.html#id4) loop with a variable which can be set to a directory on the system which contains scripts or templates. If the variables are not set, then the behavior is unchanged.

I verified this by successfully running the `multi-2x-ubuntu-1404` test. I did not believe it necessary to add a test(s) for this since the relative globs succeeded in the test.