### PR TITLE
Plugin Management and fixes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,9 +8,9 @@ provisioner:
   roles_path: ../
   require_ansible_repo: true
   ansible_verbose: true
-  http_proxy: <%= ENV['HTTP_PROXY'] %>
-  https_proxy: <%= ENV['HTTPS_PROXY'] %>
-  no_proxy: localhost,127.0.0.1
+  #http_proxy: <%= ENV['HTTP_PROXY'] %>
+  #https_proxy: <%= ENV['HTTPS_PROXY'] %>
+  #no_proxy: localhost,127.0.0.1
 
 platforms:
   - name: ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,7 @@ platforms:
         - apt-get update && apt-get install -y software-properties-common &&  add-apt-repository -y ppa:ansible/ansible
         - apt-get update && apt-get -y -q install ansible python-apt python-pycurl
       use_sudo: false
+      ansible_platform: ubuntu
   - name: debian-7
     driver_config:
       image: electrical/debian:7.3
@@ -31,6 +32,7 @@ platforms:
         - apt-get install -y -q ansible
         - apt-get install -y -q net-tools
       use_sudo: false
+      ansible_platform: debian
   - name: debian-8
     driver_config:
       image: electrical/debian:8
@@ -44,11 +46,13 @@ platforms:
         - sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
       use_sudo: false
       run_command: "/sbin/init"
+      ansible_platform: debian
   - name: centos-6
     driver_config:
       image: electrical/centos:6.4-1
       privileged: true
       use_sudo: false
+      ansible_platform: centos
   - name: centos-7
     driver_config:
       image: electrical/centos:7
@@ -61,6 +65,7 @@ platforms:
       run_command: "/usr/sbin/init"
       privileged: true
       use_sudo: false
+      ansible_platform: centos
 
 suites:
   - name: standard-2x

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ansible role for Elasticsearch.  Currently this works on Debian and RedHat based
 * Centos 6
 * Centos 7
 
-The latest Elasticsearch versions of 1.7.x and 2.1.x are actively tested.
+The latest Elasticsearch versions of 1.7.x and 2.x are actively tested.
 
 ## Usage
 
@@ -54,7 +54,18 @@ The following illustrates applying configuration parameters to an Elasticsearch 
   hosts: localhost
   roles:
     #expand to all available parameters
-    - { role: elasticsearch, es_instance_name: "node1", es_data_dir: "/opt/elasticsearch/data", es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", es_config: {node.name: "node1", cluster.name: "custom-cluster", discovery.zen.ping.unicast.hosts: "localhost:9301", http.port: 9201, transport.tcp.port: 9301, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "node1", es_data_dirs: "/opt/elasticsearch/data", es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", 
+    es_config: {
+        node.name: "node1", 
+        cluster.name: "custom-cluster",
+        discovery.zen.ping.unicast.hosts: "localhost:9301",
+        http.port: 9201,
+        transport.tcp.port: 9301,
+        node.data: false,
+        node.master: true,
+        bootstrap.mlockall: true,
+        discovery.zen.ping.multicast.enabled: false } 
+    }
   vars:
     es_scripts: false
     es_templates: false
@@ -84,7 +95,18 @@ A more complex example:
   hosts: localhost
   roles:
     #expand to all available parameters
-    - { role: elasticsearch, es_instance_name: "node1", es_data_dir: "/opt/elasticsearch/data", es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", es_config: {node.name: "node1", cluster.name: "custom-cluster", discovery.zen.ping.unicast.hosts: "localhost:9301", http.port: 9201, transport.tcp.port: 9301, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "node1", es_data_dirs: "/opt/elasticsearch/data", es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", 
+    es_config: {
+        node.name: "node1", 
+        cluster.name: "custom-cluster", 
+        discovery.zen.ping.unicast.hosts: "localhost:9301", 
+        http.port: 9201, 
+        transport.tcp.port: 9301, 
+        node.data: false, 
+        node.master: true, 
+        bootstrap.mlockall: true, 
+        discovery.zen.ping.multicast.enabled: false } 
+    }
   vars:
     es_scripts: false
     es_templates: false
@@ -126,8 +148,28 @@ recommended in any multi node cluster configuration.
 
 - hosts: data_nodes
   roles:
-    - { role: elasticsearch, es_instance_name: "node1", es_data_dir: "/opt/elasticsearch", es_config: { "discovery.zen.ping.multicast.enabled": false, discovery.zen.ping.unicast.hosts: "elastic02:9300", http.port: 9200, transport.tcp.port: 9300, node.data: true, node.master: false, bootstrap.mlockall: false, discovery.zen.ping.multicast.enabled: false } }
-    - { role: elasticsearch, es_instance_name: "node2", es_config: { "discovery.zen.ping.multicast.enabled": false, discovery.zen.ping.unicast.hosts: "elastic02:9300", http.port: 9201, transport.tcp.port: 9301, node.data: true, node.master: false, bootstrap.mlockall: false, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "node1", es_data_dirs: "/opt/elasticsearch", 
+    es_config: {
+        "discovery.zen.ping.multicast.enabled": false,
+        discovery.zen.ping.unicast.hosts: "elastic02:9300",
+        http.port: 9200,
+        transport.tcp.port: 9300,
+        node.data: true,
+        node.master: false,
+        bootstrap.mlockall: false,
+        discovery.zen.ping.multicast.enabled: false } 
+    }
+    - { role: elasticsearch, es_instance_name: "node2", 
+    es_config: {
+        "discovery.zen.ping.multicast.enabled": false,
+        discovery.zen.ping.unicast.hosts: "elastic02:9300",
+        http.port: 9201,
+        transport.tcp.port: 9301,
+        node.data: true,
+        node.master: false,
+        bootstrap.mlockall: false,
+        discovery.zen.ping.multicast.enabled: false } 
+    }
   vars:
     es_scripts: false
     es_templates: false
@@ -159,7 +201,7 @@ Following variables affect the versions installed:
 * ```es_version``` (e.g. "1.5.2").  
 * ```es_start_service``` (true (default) or false)
 * ```es_plugins_reinstall``` (true or false (default) )
-* ```es_plugins``` (an array of plugin definitons e.g.:
+* ```es_plugins``` (an array of plugin definitions e.g.:
 
 ```
   es_plugins:
@@ -183,10 +225,12 @@ By default, each node on a host will be installed to use unique pid, plugin, wor
 controlled by the following parameters:
 
 * ```es_pid_dir``` - defaults to "/var/run/elasticsearch".
-* ```es_data_dir``` - defaults to "/var/lib/elasticsearch".
+* ```es_data_dirs``` - defaults to "/var/lib/elasticsearch".  This can be a list or comma separated string e.g. ["/opt/elasticsearch/data-1","/opt/elasticsearch/data-2"] or "/opt/elasticsearch/data-1,/opt/elasticsearch/data-2"
 * ```es_log_dir``` - defaults to "/var/log/elasticsearch".
 * ```es_work_dir``` - defaults to "/tmp/elasticsearch".
 * ```es_plugin_dir``` - defaults to "/usr/share/elasticsearch/plugins".
+* ```es_restart_on_change``` - defaults to true.  If false, changes will not result in Elasticsearch being restarted.
+* ```es_plugins_reinstall``` - defaults to false.  If true, all currently installed plugins will be removed from a node.  Listed plugins will then be re-installed.  
 
 This role ships with sample scripts and templates located in the [files/scripts/](files/scripts) and [files/templates/](files/templates) directories, respectively. These variables are used with the Ansible [with_fileglob](http://docs.ansible.com/ansible/playbooks_loops.html#id4) loop. When setting the globs, be sure to use an absolute path.
 * ```es_scripts_fileglob``` - defaults to `<role>/files/scripts/`.
@@ -203,3 +247,8 @@ all supported platforms.
 Elasticsearch restarted where required.
 * Systemd is used for Ubuntu versions >= 15, Debian >=8, Centos >=7.  All other versions use init for service scripts.
 
+## IMPORTANT NOTES RE PLUGIN MANAGEMENT
+
+* If the ES version is changed, all plugins will be removed.  Those listed in the playbook will be re-installed.  This is behaviour is required in ES 2.x.
+* If no plugins are listed in the playbook for a node, all currently installed plugins will be removed.
+* The role does not currently support automatic detection of differences between installed and listed plugins (other than if none are listed).   Should users wish to change installed plugins should set es_plugins_reinstall to true.  This will cause all currently installed plugins to be removed and those listed to be installed.  Change detection will be implemented in future releases.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ es_group: elasticsearch
 es_config: {}
 #Need to provide default directories
 es_pid_dir: "/var/run/elasticsearch"
-es_data_dir: "/var/lib/elasticsearch"
+es_data_dirs: "/var/lib/elasticsearch"
 es_log_dir: "/var/log/elasticsearch"
 es_work_dir: "/tmp/elasticsearch"
 es_plugin_dir: "/usr/share/elasticsearch/plugins"

--- a/filter_plugins/custom.py
+++ b/filter_plugins/custom.py
@@ -1,0 +1,26 @@
+__author__ = 'dale mcdiarmid'
+
+import re
+
+def modify_list(values=[], pattern='', replacement='', ignorecase=False):
+    ''' Perform a `re.sub` on every item in the list'''
+    if ignorecase:
+        flags = re.I
+    else:
+        flags = 0
+    _re = re.compile(pattern, flags=flags)
+    return [_re.sub(replacement, value) for value in values]
+
+def append_to_list(values=[], suffix=''):
+    if isinstance(values, basestring):
+        values = values.split(',')
+    return [str(value+suffix) for value in values]
+
+def array_to_str(values=[],separator=','):
+    return separator.join(values)
+
+class FilterModule(object):
+    def filters(self):
+        return {'modify_list': modify_list,
+        'append_to_list':append_to_list,
+        'array_to_str':array_to_str}

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -17,32 +17,35 @@
 
 #For directories we also use the {{inventory_hostname}}-{{ es_instance_name }} - this helps if we have a shared SAN.
 
-- set_fact: pid_dir={{ es_pid_dir }}/{{inventory_hostname}}-{{ es_instance_name }}
+- set_fact: instance_suffix={{inventory_hostname}}-{{ es_instance_name }}
 
-- set_fact: data_dir={{ es_data_dir }}/{{inventory_hostname}}-{{ es_instance_name }}
+- set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
 
-- set_fact: log_dir={{ es_log_dir }}/{{inventory_hostname}}-{{ es_instance_name }}
+- set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
 
-- set_fact: work_dir={{ es_work_dir }}/{{inventory_hostname}}-{{ es_instance_name }}
+- set_fact: work_dir={{ es_work_dir }}/{{instance_suffix}}
 
 #Create required directories
-- name: Create PID Directory
-  file: path={{ pid_dir }} state=directory owner={{ es_user }} group={{ es_group }}
+- name: Create Directories
+  file: path={{ item }} state=directory owner={{ es_user }} group={{ es_group }}
+  with_items:
+    - "{{pid_dir}}"
+    - "{{work_dir}}"
+    - "{{log_dir}}"
+    - "{{conf_dir}}"
+    - "{{plugin_dir}}"
 
-- name: Create data dir
-  file: state=directory path={{ data_dir }} owner={{ es_user }} group={{ es_group }}
+- debug: msg="Data Dirs {{es_data_dirs}}"
 
-- name: Create work dir
-  file: state=directory path={{ work_dir }} owner={{ es_user }} group={{ es_group }}
+- set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
 
-- name: Create log dir
-  file: state=directory path={{ log_dir }} owner={{ es_user }} group={{ es_group }}
+- debug: msg="Data Dirs {{data_dirs}}"
 
-- name: Create Config Directory
-  file: path={{ conf_dir }} state=directory owner={{ es_user }} group={{ es_group }}
+- name: Create Data Directories
+  file: path={{ item }} state=directory owner={{ es_user }} group={{ es_group }}
+  with_items:
+    - "{{data_dirs}}"
 
-- name: Create Plugin Directory
-  file: state=directory path={{ plugin_dir }} owner={{ es_user }} group={{ es_group }}
 
 #Copy the config template
 - name: Copy Configuration File
@@ -92,3 +95,11 @@
 
 - name: Delete Default Sysconfig File
   file: dest=/usr/lib/systemd/system/elasticsearch.service state=absent
+
+- name: Delete Default Configuration File
+  file: dest=/etc/elasticsearch/elasticsearch.yml state=absent
+
+- name: Delete Default Logging File
+  file: dest=/etc/elasticsearch/logging.yml state=absent
+
+- debug: msg="Data Dirs {{data_dirs}}"

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -1,22 +1,32 @@
 ---
 
-#es_plugins_reinstall will be set to true if elasticsearch_install.changed i.e. we have changed ES version
+#es_plugins_reinstall will be set to true if elasticsearch_install.changed i.e. we have changed ES version, or if no plugins listed. Otherwise it is false and requires explicitly setting.
 - set_fact: es_plugins_reinstall=true
-  when: elasticsearch_install.changed
+  when: elasticsearch_install.changed or es_plugins is not defined or es_plugins is none
+
+- set_fact: list_command="list"
+
+- set_fact: list_command="--list"
+  when: es_version | version_compare('2.0', '<')
 
 #List currently installed plugins
+- shell: "{{es_home}}/bin/plugin {{list_command}} | sed -n '1!p' | cut -d '-' -f2-"
+  register: installed_plugins
+  changed_when: False
+  environment:
+      CONF_DIR: "{{ conf_dir }}"
+      ES_INCLUDE: "{{ instance_default_file }}"
 
-
-
-#This needs to removed installed plugins not those listed
+#This needs to removes any currently installed plugins
 - name: Remove elasticsearch plugins
-  command: "{{es_home}}/bin/plugin remove {{ item.plugin }} --silent"
+  command: "{{es_home}}/bin/plugin remove {{item}} --silent"
   ignore_errors: yes
-  with_items: es_plugins
-  when: es_plugins_reinstall
+  with_items: installed_plugins.stdout_lines
+  when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"
+    ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
   #debug: var=item
@@ -25,7 +35,7 @@
   failed_when: "'Failed to install' in plugin_installed.stderr"
   changed_when: plugin_installed.rc == 0
   with_items: es_plugins
-  when: ansible_os_family == 'RedHat' or ansible_os_family == 'Debian'
+  when: es_plugins is defined and not es_plugins is none
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - include: elasticsearch-scripts.yml
   when: es_scripts
 - include: elasticsearch-plugins.yml
-  when: es_plugins is defined
+  when: es_plugins is defined or es_plugins_reinstall
 - include: elasticsearch-service.yml
 - include: elasticsearch-templates.yml
   when: es_templates

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -9,7 +9,7 @@ ES_HOME={{es_home}}
 CONF_DIR={{conf_dir}}
 
 # Elasticsearch data directory
-DATA_DIR={{data_dir}}
+DATA_DIR={{ data_dirs | array_to_str }}
 
 # Elasticsearch logs directory
 LOG_DIR={{log_dir}}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -16,7 +16,7 @@ node.name: {{inventory_hostname}}-{{es_instance_name}}
 # Path to directory containing configuration (this file and logging.yml):
 path.conf: {{ conf_dir }}
 
-path.data: {{ data_dir }}
+path.data: {{ data_dirs | array_to_str }}
 
 path.work: {{ work_dir }}
 

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -10,7 +10,7 @@
 # Modified by Nicolas Huray for Elasticsearch <nicolas.huray@gmail.com>.
 #
 ### BEGIN INIT INFO
-# Provides:          elasticsearch
+# Provides:          {{es_instance_name}}_{{default_file | basename}}
 # Required-Start:    $network $remote_fs $named
 # Required-Stop:     $network $remote_fs $named
 # Default-Start:     2 3 4 5

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 Environment=ES_HOME={{es_home}}
 Environment=CONF_DIR={{conf_dir}}
-Environment=DATA_DIR={{data_dir}}
+Environment=DATA_DIR={{ data_dirs | array_to_str }}
 Environment=LOG_DIR={{log_dir}}
 Environment=PID_DIR={{pid_dir}}
 EnvironmentFile=-{{instance_default_file}}

--- a/test/integration/config.yml
+++ b/test/integration/config.yml
@@ -4,7 +4,7 @@
   hosts: localhost
   roles:
     #expand to all available parameters
-    - { role: elasticsearch, es_instance_name: "node1", es_data_dir: "/opt/elasticsearch/data", es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", es_config: {node.name: "node1", cluster.name: "custom-cluster", discovery.zen.ping.unicast.hosts: "localhost:9301", http.port: 9201, transport.tcp.port: 9301, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "node1", es_data_dirs: ["/opt/elasticsearch/data-1","/opt/elasticsearch/data-2"], es_log_dir: "/opt/elasticsearch/logs", es_work_dir: "/opt/elasticsearch/temp", es_config: {node.name: "node1", cluster.name: "custom-cluster", discovery.zen.ping.unicast.hosts: "localhost:9301", http.port: 9201, transport.tcp.port: 9301, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
   vars:
     es_scripts: false
     es_templates: false

--- a/test/integration/helpers/serverspec/config_spec.rb
+++ b/test/integration/helpers/serverspec/config_spec.rb
@@ -30,7 +30,7 @@ shared_examples 'config::init' do |es_version|
     it { should contain 'bootstrap.mlockall: true' }
     it { should contain 'discovery.zen.ping.unicast.hosts: localhost:9301' }
     it { should contain 'path.conf: /etc/elasticsearch/node1' }
-    it { should contain 'path.data: /opt/elasticsearch/data/localhost-node1' }
+    it { should contain 'path.data: /opt/elasticsearch/data-1/localhost-node1,/opt/elasticsearch/data-2/localhost-node1' }
     it { should contain 'path.work: /opt/elasticsearch/temp/localhost-node1' }
     it { should contain 'path.logs: /opt/elasticsearch/logs/localhost-node1' }
   end
@@ -41,7 +41,12 @@ shared_examples 'config::init' do |es_version|
     it { should be_owned_by 'elasticsearch' }
   end
 
-  describe file('/opt/elasticsearch/data/localhost-node1') do
+  describe file('/opt/elasticsearch/data-1/localhost-node1') do
+    it { should be_directory }
+    it { should be_owned_by 'elasticsearch' }
+  end
+
+  describe file('/opt/elasticsearch/data-2/localhost-node1') do
     it { should be_directory }
     it { should be_owned_by 'elasticsearch' }
   end
@@ -80,6 +85,27 @@ shared_examples 'config::init' do |es_version|
       expect(command.stdout).to match(es_version)
       expect(command.exit_status).to eq(0)
     end
+  end
+
+
+  describe file('/etc/init.d/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/default/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/sysconfig/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/usr/lib/systemd/system/elasticsearch.service') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/elasticsearch/elasticsearch.yml') do
+    it { should_not exist }
   end
 
   #Not copied on Debian 8

--- a/test/integration/helpers/serverspec/multi_spec.rb
+++ b/test/integration/helpers/serverspec/multi_spec.rb
@@ -29,7 +29,7 @@ shared_examples 'multi::init' do  |es_version,plugins|
     it { should contain 'node.name: localhost-node1' }
     it { should_not contain 'bootstrap.mlockall: true' }
     it { should contain 'path.conf: /etc/elasticsearch/node1' }
-    it { should contain 'path.data: /var/lib/elasticsearch/localhost-node1' }
+    it { should contain 'path.data: /opt/elasticsearch/data-1/localhost-node1,/opt/elasticsearch/data-2/localhost-node1' }
     it { should contain 'path.work: /tmp/elasticsearch/localhost-node1' }
     it { should contain 'path.logs: /var/log/elasticsearch/localhost-node1' }
   end
@@ -46,7 +46,7 @@ shared_examples 'multi::init' do  |es_version,plugins|
     it { should contain 'node.name: localhost-master' }
     it { should contain 'bootstrap.mlockall: true' }
     it { should contain 'path.conf: /etc/elasticsearch/master' }
-    it { should contain 'path.data: /opt/elasticsearch/localhost-master' }
+    it { should contain 'path.data: /opt/elasticsearch/master/localhost-master' }
     it { should contain 'path.work: /tmp/elasticsearch/localhost-master' }
     it { should contain 'path.logs: /var/log/elasticsearch/localhost-master' }
   end
@@ -129,16 +129,18 @@ shared_examples 'multi::init' do  |es_version,plugins|
   end
 
   #Confirm that the data directory has only been set for the first node
-  describe file('/opt/elasticsearch/localhost-master') do
+  describe file('/opt/elasticsearch/master/localhost-master') do
     it { should be_directory }
     it { should be_owned_by 'elasticsearch' }
   end
 
-  describe file('/opt/elasticsearch/localhost-node1') do
-    it { should_not exist }
+  describe file('/opt/elasticsearch/data-1/localhost-node1') do
+    it { should be_directory }
+    it { should be_owned_by 'elasticsearch' }
   end
 
-  describe file('/var/lib/elasticsearch/localhost-node1') do
+
+  describe file('/opt/elasticsearch/data-2/localhost-node1') do
     it { should be_directory }
     it { should be_owned_by 'elasticsearch' }
   end
@@ -203,6 +205,25 @@ shared_examples 'multi::init' do  |es_version,plugins|
     end
   end
 
+  describe file('/etc/init.d/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/default/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/sysconfig/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/usr/lib/systemd/system/elasticsearch.service') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/elasticsearch/elasticsearch.yml') do
+    it { should_not exist }
+  end
 
 
 

--- a/test/integration/helpers/serverspec/package_spec.rb
+++ b/test/integration/helpers/serverspec/package_spec.rb
@@ -83,5 +83,25 @@ shared_examples 'package::init' do  |es_version,plugins|
     end
   end
 
+  describe file('/etc/init.d/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/default/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/sysconfig/elasticsearch') do
+    it { should_not exist }
+  end
+
+  describe file('/usr/lib/systemd/system/elasticsearch.service') do
+    it { should_not exist }
+  end
+
+  describe file('/etc/elasticsearch/elasticsearch.yml') do
+    it { should_not exist }
+  end
+
 end
 

--- a/test/integration/helpers/serverspec/standard_spec.rb
+++ b/test/integration/helpers/serverspec/standard_spec.rb
@@ -63,5 +63,9 @@ shared_examples 'standard::init' do |es_version|
     it { should_not exist }
   end
 
+  describe file('/etc/elasticsearch/elasticsearch.yml') do
+    it { should_not exist }
+  end
+
 end
 

--- a/test/integration/multi.yml
+++ b/test/integration/multi.yml
@@ -3,8 +3,8 @@
 - name: Elasticsearch Multi tests
   hosts: localhost
   roles:
-    - { role: elasticsearch, es_instance_name: "master", es_data_dir: "/opt/elasticsearch", es_heap_size: "1g", es_config: { "discovery.zen.ping.multicast.enabled": false, discovery.zen.ping.unicast.hosts: "localhost:9300", http.port: 9200, transport.tcp.port: 9300, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
-    - { role: elasticsearch, es_instance_name: "node1", es_config: { "discovery.zen.ping.multicast.enabled": false,  discovery.zen.ping.unicast.hosts: "localhost:9300", http.port: 9201, transport.tcp.port: 9301, node.data: true, node.master: false, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "master", es_data_dirs: ["/opt/elasticsearch/master"], es_heap_size: "1g", es_config: { "discovery.zen.ping.multicast.enabled": false, discovery.zen.ping.unicast.hosts: "localhost:9300", http.port: 9200, transport.tcp.port: 9300, node.data: false, node.master: true, bootstrap.mlockall: true, discovery.zen.ping.multicast.enabled: false } }
+    - { role: elasticsearch, es_instance_name: "node1", es_data_dirs: "/opt/elasticsearch/data-1,/opt/elasticsearch/data-2", es_config: { "discovery.zen.ping.multicast.enabled": false,  discovery.zen.ping.unicast.hosts: "localhost:9300", http.port: 9201, transport.tcp.port: 9301, node.data: true, node.master: false, discovery.zen.ping.multicast.enabled: false } }
   vars:
     es_scripts: true
     es_templates: true


### PR DESCRIPTION
This pull requests provides the following:
1. Improved plugin support. We now remove and re-install all plugins if the ES version changes (as required by Elasticsearch). Otherwise we only re-install plugins if the user sets the appropriate flag. 
2. Currently we don't dif the the installed vs the requested but this could be added.
3. Fixes known issue with data dirs containing multiple paths and not all being modified.
4. Fixes known issues with init script and more than one node on a machine.
5. Refactors areas using with_items
6. Adds and fixes test issues.
7. Fix for Kitchen CLI issue