### PR TITLE
ELS < 1.0 should start systemd instance in foreground

### DIFF
--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -16,6 +16,9 @@ User={{es_user}}
 Group={{es_group}}
 
 ExecStart={{es_home}}/bin/elasticsearch \
+{% if es_version | version_compare('1.0.0', '<') %}
+                                        -f \
+{% endif %}
                                         -Des.pidfile=${PID_DIR}/elasticsearch.pid \
                                         -Des.default.path.home=${ES_HOME} \
                                         -Des.default.path.logs=${LOG_DIR} \


### PR DESCRIPTION
Old instances have a -f flag to run in foreground mode. 

Without this flag, the instance is launched with shell & operator then systemd thinks instance doesn't work and kill the process.