### PR TITLE
added force option for package install, enabling users to downgrade

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -8,7 +8,7 @@
   when: es_use_repository
 
 - name: Debian - Ensure elasticsearch is installed
-  apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present cache_valid_time=86400
+  apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present force=yes cache_valid_time=86400
   when: es_use_repository
   register: elasticsearch_install
 


### PR DESCRIPTION
use of the force=yes option here could be undesirable, but it does enable users to freely switch versions of elasticsearch on playbook runs.