### PR TITLE
Added flag install_java (default true), to allow skipping java instal…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ es_version_lock: false
 es_use_repository: true
 es_start_service: true
 update_java: false
+install_java: true
 es_restart_on_change: true
 es_plugins_reinstall: false
 es_scripts: false

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -8,8 +8,8 @@
 
 - name: RedHat - Ensure Java is installed
   yum: name={{ java }} state={{java_state}}
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and install_java
   
 - name: Debian - Ensure Java is installed
   apt: name={{ java }} state={{java_state}} update_cache=yes force=yes
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and install_java


### PR DESCRIPTION
…lation, in case it has already been done, without package manager.

Solves https://github.com/elastic/ansible-elasticsearch/issues/94

The flag can be used as follows:

```YAML
- name: Elasticsearch skipping Java install
  hosts: localhost
  roles:
    #expand to all available parameters
    - { role: elasticsearch, 
        install_java: false,
        es_instance_name: "node1", 
        es_data_dirs: "/opt/elasticsearch/data", 
        es_log_dir: "/opt/elasticsearch/logs", 
        es_work_dir: "/opt/elasticsearch/temp", 
        es_config: {
          node.name: "node1", 
          cluster.name: "custom-cluster",
          discovery.zen.ping.unicast.hosts: "localhost:9301",
          http.port: 9201,
          transport.tcp.port: 9301,
          node.data: false,
          node.master: true,
          bootstrap.mlockall: true,
          discovery.zen.ping.multicast.enabled: false } 
    }
  vars:
    es_scripts: false
    es_templates: false
    es_version_lock: false
    es_heap_size: 1g
```