### PR TITLE
Allow for selective command line task execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The simplest configuration therefore consists of:
 
 The above installs a single node 'node1' on the hosts 'localhost'.
 
+This role also uses [Ansible tags](http://docs.ansible.com/ansible/playbooks_tags.html). Run your playbook with the `--list-tasks` flag for more information.
+
 ### Basic Elasticsearch Configuration
 
 All Elasticsearch configuration parameters are supported.  This is achieved using a configuration map parameter 'es_config' which is serialized into the elasticsearch.yml file.  

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -11,19 +11,31 @@
 
 
 - set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or (ansible_distribution == 'CentOS' and ansible_distribution_version | version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>=')) }}
+  tags:
+      - always
 
 - set_fact: instance_sysd_script={{sysd_script | dirname }}/{{es_instance_name}}_{{sysd_script | basename}}
   when: use_system_d
+  tags:
+      - always
 
 #For directories we also use the {{inventory_hostname}}-{{ es_instance_name }} - this helps if we have a shared SAN.
 
 - set_fact: instance_suffix={{inventory_hostname}}-{{ es_instance_name }}
+  tags:
+      - always
 
 - set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
+  tags:
+      - always
 
 - set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
+  tags:
+      - always
 
 - set_fact: work_dir={{ es_work_dir }}/{{instance_suffix}}
+  tags:
+      - always
 
 #Create required directories
 - name: Create Directories
@@ -36,6 +48,8 @@
     - "{{plugin_dir}}"
 
 - set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
+  tags:
+      - always
 
 - name: Create Data Directories
   file: path={{ item }} state=directory owner={{ es_user }} group={{ es_group }}

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -2,11 +2,17 @@
 
 #es_plugins_reinstall will be set to true if elasticsearch_install.changed i.e. we have changed ES version, or if no plugins listed. Otherwise it is false and requires explicitly setting.
 - set_fact: es_plugins_reinstall=true
-  when: elasticsearch_install.changed or es_plugins is not defined or es_plugins is none
+  when: (elasticsearch_install is defined and elasticsearch_install.changed) or es_plugins is not defined or es_plugins is none
+  tags:
+      - always
 
 - set_fact: list_command="list"
+  tags:
+      - always
 - set_fact: list_command="--list"
   when: es_version | version_compare('2.0', '<')
+  tags:
+      - always
 
 #List currently installed plugins
 - shell: "{{es_home}}/bin/plugin {{list_command}} | sed -n '1!p' | cut -d '-' -f2-"

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -1,9 +1,13 @@
 ---
 
 - set_fact: es_script_dir={{ es_conf_dir }}/{{es_instance_name}}
+  tags:
+      - always
 
 - set_fact: es_script_dir={{es_config['path.scripts']}}
   when: es_config['path.scripts'] is defined
+  tags:
+      - always
 
 - name: Create script dir
   file: state=directory path={{ es_script_dir }} owner={{ es_user }} group={{ es_group }}

--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -11,9 +11,13 @@
   with_fileglob: "{{ es_templates_fileglob }}"
 
 - set_fact: http_port=9200
+  tags:
+      - always
 
 - set_fact: http_port={{es_config['http.port']}}
   when: es_config['http.port'] is defined
+  tags:
+      - always
 
 - name: Wait for elasticsearch to startup
   wait_for: port={{http_port}} delay=10

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,10 +1,20 @@
 ---
 
 - set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name}}_{{default_file | basename}}
+  tags:
+      - always
 - set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name}}_{{init_script | basename}}
+  tags:
+      - always
 - set_fact: conf_dir={{ es_conf_dir }}/{{es_instance_name}}
+  tags:
+      - always
 - set_fact: plugin_dir={{ es_plugin_dir }}/{{es_instance_name}}
+  tags:
+      - always
 - set_fact: m_lock_enabled={{ es_config['bootstrap.mlockall'] is defined and es_config['bootstrap.mlockall'] == True }}
+  tags:
+      - always
 
 - debug: msg="Node configuration {{ es_config }} "
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,8 @@
       - check
 - name: os-specific vars
   include_vars: "{{ansible_os_family}}.yml"
+  tags:
+      - always
 - include: java.yml
   tags:
       - java

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,32 @@
 ---
 - name: check-parameters
   include: checkParameters.yml
+  tags:
+      - check
 - name: os-specific vars
   include_vars: "{{ansible_os_family}}.yml"
 - include: java.yml
+  tags:
+      - java
 - include: elasticsearch.yml
+  tags:
+      - install
 - include: elasticsearch-config.yml
+  tags:
+      - config
 - include: elasticsearch-scripts.yml
   when: es_scripts
+  tags:
+      - scripts
 - include: elasticsearch-plugins.yml
   when: es_plugins is defined or es_plugins_reinstall
+  tags:
+      - plugins
 - include: elasticsearch-service.yml
+  tags:
+      - service
 - include: elasticsearch-templates.yml
   when: es_templates
+  tags:
+      - templates
 - meta: flush_handlers


### PR DESCRIPTION
Adding tags to the `tasks/main.yml` allows the user to skip whole sets of tasks from the command line.

```
% ansible-playbook ... ansible-elasticsearch-playbook.yaml --list-tasks
...
    tasks:
      cyverse.elasticsearch : check-parameters	TAGS: [check]
      cyverse.elasticsearch : os-specific vars	TAGS: []
      include	TAGS: [java]
      include	TAGS: [install]
      include	TAGS: [config]
      include	TAGS: [scripts]
      include	TAGS: [plugins]
      include	TAGS: [service]
      include	TAGS: [templates]
```

```
% ansible-playbook ... ansible-elasticsearch-playbook.yaml --skip-tags "check,java,install" --list-tasks
...
    tasks:
      cyverse.elasticsearch : os-specific vars	TAGS: []
      include	TAGS: [config]
      include	TAGS: [scripts]
      include	TAGS: [plugins]
      include	TAGS: [service]
      include	TAGS: [templates]
```

Note: When you use `--list-tasks` with `--tags ...`, `include:` directives will still be listed. However, when you execute the playbook, only tasks which are marked with the selected tags will be executed.

# Example
So, if you only wanted to update some plugins, you would execute the following command;
```
% ansible-playbook ... ansible-elasticsearch-playbook.yaml --tags "plugins" 
```

# Other Details
Due to this role's use of the `set_fact` module, many of these had to have the `- always` tag applied to ensure that these tasks are always executed, thus preventing errors with conditional task execution (i.e. `when` clauses can/will break).

# Testing
No tests were added. I've tested this with the example listed above (`--tags "plugins"`).