### PR TITLE
Adding with_items defaults

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -20,7 +20,7 @@
 - name: Remove elasticsearch plugins
   command: "{{es_home}}/bin/plugin remove {{item}} --silent"
   ignore_errors: yes
-  with_items: "{{ installed_plugins.stdout_lines }}"
+  with_items: "{{ installed_plugins.stdout_lines | default([]) }}"
   when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
   notify: restart elasticsearch
   environment:
@@ -34,7 +34,7 @@
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
-  with_items: "{{ es_plugins }}"
+  with_items: "{{ es_plugins | default([]) }}"
   when: es_plugins is defined and not es_plugins is none
   notify: restart elasticsearch
   environment:

--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -24,4 +24,4 @@
 
 - name: Install template(s)
   command: "curl -sL -XPUT http://localhost:{{http_port}}/_template/{{item}} -d @/etc/elasticsearch/templates/{{item}}.json"
-  with_items: "{{ resultstemplate.stdout_lines }}"
+  with_items: "{{ resultstemplate.stdout_lines | default([]) }}"


### PR DESCRIPTION
Somehow Ansible still processes the "with_items" even in skipped tasks. This takes care of the problem.

Example

```
TASK: [elasticsearch | shell {{es_home}}/bin/plugin {{list_command}} | sed -n '1!p' | cut -d '-' -f2-] *** 
skipping: [es-01]

TASK: [elasticsearch | Remove elasticsearch plugins] ************************** 
fatal: [es-01] => with_items expects a list or a set

FATAL: all hosts have already failed -- aborting
```