### PR TITLE
enable specify java version (package name)

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
-java: "openjdk-7-jre-headless"
+java: "{{ es_java | default('openjdk-7-jre-headless') }}"
 default_file: "/etc/default/elasticsearch"
 es_home: "/usr/share/elasticsearch"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
-java: "java-1.8.0-openjdk.x86_64"
+java: "{{ es_java | default('java-1.8.0-openjdk.x86_64') }}"
 default_file: "/etc/sysconfig/elasticsearch"
 es_home: "/usr/share/elasticsearch"


### PR DESCRIPTION
If **es_java** variable is set, it will use that as the java package name
instead of the default package.
This can be handy for example when running on Ubuntu 16.04 (which is not yet officially supported).

Example:
```
roles:
  - { role: elasticsearch, es_java: "openjdk-8-jre-headless", es_instance_name: "node1" }
```
The specified package must be available in the currently enabled repositories.