### PR TITLE
Improve idempotency for plugins management

### DIFF
--- a/filter_plugins/custom.py
+++ b/filter_plugins/custom.py
@@ -19,8 +19,28 @@ def append_to_list(values=[], suffix=''):
 def array_to_str(values=[],separator=','):
     return separator.join(values)
 
+def parse_plugin_repo(string):
+    elements = string.split("/")
+    ''' We first consider the simplest form: pluginname'''
+    repo = elements[0]
+    
+    '''We consider the form: username/pluginname'''
+    if len(elements) > 1:
+        repo = elements[1]
+    '''
+    remove elasticsearch- prefix
+    remove es- prefix
+    '''
+    for string in ("elasticsearch-", "es-"):
+        if repo.startswith(string):
+            return repo[len(string):]
+    return repo
+
 class FilterModule(object):
     def filters(self):
-        return {'modify_list': modify_list,
-        'append_to_list':append_to_list,
-        'array_to_str':array_to_str}
+        return {
+            'modify_list': modify_list,
+            'append_to_list': append_to_list,
+            'array_to_str': array_to_str,
+            'parse_plugin_repo': parse_plugin_repo
+        }

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -35,7 +35,9 @@
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins }}"
-  when: es_plugins is defined and not es_plugins is none
+  when:
+    - es_plugins is defined and not es_plugins is none
+    - item.plugin | parse_plugin_repo not in installed_plugins.stdout_lines and es_plugins_reinstall
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"


### PR DESCRIPTION
Don't install plugin when it exists and without asking it explicitly by setting `es_plugins_reinstall: true`. This make the plugin management idempotent.

PS: The filter is taken from the ansible's [elasticsearch_plugin](https://github.com/barryib/ansible-modules-extras/blob/aaa34b03c11d2b53e6a7dfe209423b9da312d250/packaging/elasticsearch_plugin.py)