### PR TITLE
Using with_glob breaks in Ansible 2.1.0.0-1.

### DIFF
--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -18,4 +18,4 @@
 
 - name: Copy scripts to elasticsearch
   copy: src={{ item }} dest={{ es_script_dir }} owner={{ es_user }} group={{ es_group }}
-  with_fileglob: es_scripts_fileglob
+  with_fileglob: "{{ es_scripts_fileglob }}"

--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -9,8 +9,7 @@
 - name: Copy templates to elasticsearch
   copy: src={{ item }} dest=/etc/elasticsearch/templates owner={{ es_user }} group={{ es_group }}
   when: es_templates_fileglob is defined
-  with_fileglob:
-    - "{{ es_templates_fileglob }}"
+  with_fileglob: "{{ es_templates_fileglob }}"
 
 - set_fact: http_port=9200
   tags:


### PR DESCRIPTION
As mentioned in the bottom of #119 I am seeing issues when using with_fileglob as a variable.

```  with_fileglob: "{{ es_templates_fileglob }}"```

Ansible version: 2.1.0.0-1.

If I role back to Ansible 2.0.2 all is okay.

```
TASK [ansible-elasticsearch : Copy templates to elasticsearch] *****************
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this will be a fatal error.: 'es_templates_fileglob' is undefined.

This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
fatal: [elk1]: FAILED! => {"failed": true, "msg": "'item' is undefined"}
```

Upon looking into this, I noticed the issue seems to be the way the variable is declared, since its using "-", which I assume to Ansible its think its going to get multiple values (as you use this approach with_items.)

I have updated it to use this (and to be more consent) which fixed the problem.  