### PR TITLE
Add support for custom Debian repository; allow repository key to be set to false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ es_major_version: "2.x"
 es_version: "2.2.0"
 es_version_lock: false
 es_use_repository: true
+es_apt_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
+es_apt_url: "deb http://packages.elastic.co/elasticsearch/{{ es_major_version }}/debian stable main"
 es_start_service: true
 es_java_install: true
 update_java: false

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -6,11 +6,11 @@
   when: es_allow_downgrades
 
 - name: Debian - Add Elasticsearch repository key
-  apt_key: url="http://packages.elasticsearch.org/GPG-KEY-elasticsearch" state=present
-  when: es_use_repository
+  apt_key: url="{{ es_apt_key }}" state=present
+  when: es_use_repository and es_apt_key
 
 - name: Debian - add elasticsearch repository
-  apt_repository: repo="deb http://packages.elastic.co/elasticsearch/{{ es_major_version }}/debian stable main" state=present
+  apt_repository: repo="{{ es_apt_url }}" state=present
   when: es_use_repository
 
 - name: Debian - Ensure elasticsearch is installed

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -27,7 +27,7 @@
 - name: Remove elasticsearch plugins
   command: "{{es_home}}/bin/plugin remove {{item}} --silent"
   ignore_errors: yes
-  with_items: "{{ installed_plugins.stdout_lines }}"
+  with_items: "{{ installed_plugins.stdout_lines | default([]) }}"
   when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
   notify: restart elasticsearch
   environment:
@@ -41,8 +41,8 @@
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
-  with_items: "{{ es_plugins }}"
-  when: es_plugins is defined and not es_plugins is none and es_plugins_reinstall
+  with_items: "{{ es_plugins | default([]) }}"
+  when: not es_plugins is none and es_plugins_reinstall
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"

--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -8,9 +8,8 @@
 
 - name: Copy templates to elasticsearch
   copy: src={{ item }} dest=/etc/elasticsearch/templates owner={{ es_user }} group={{ es_group }}
-  when: es_templates_fileglob is defined
   with_fileglob:
-    - "{{ es_templates_fileglob }}"
+    - "{{ es_templates_fileglob | default('') }}"
 
 - set_fact: http_port=9200
   tags:
@@ -30,4 +29,4 @@
 
 - name: Install template(s)
   command: "curl -sL -XPUT http://localhost:{{http_port}}/_template/{{item}} -d @/etc/elasticsearch/templates/{{item}}.json"
-  with_items: "{{ resultstemplate.stdout_lines }}"
+  with_items: "{{ resultstemplate.stdout_lines | default([]) }}"


### PR DESCRIPTION
I have a number of hosts that cannot do direct downloads. This minor change enables simplictic support of custom apt repositories, and also allows the repository signing key url to be set to false for unsigned repositories or for when es_apt_url is a ppa.

I have no rpm distributions to test on, so I have not made the same change to that side of the playbook. It might be worth for someone to do this, though, as it seems like a good idea to move these hardcoded values away from the actual tasks and into the variable defaults.