### PR TITLE
template and init script fixes

### DIFF
--- a/tasks/elasticsearch-templates.yml
+++ b/tasks/elasticsearch-templates.yml
@@ -22,12 +22,13 @@
       - always
 
 - name: Wait for elasticsearch to startup
-  wait_for: port={{http_port}} delay=10
+  wait_for: host="{{ es_config['network.host'] | default('localost') }}" port={{http_port}} delay=10
+  tags: testlookup
 
-- name: Get template files 
+- name: Get template files
   shell: find . -maxdepth 1 -type f | sed "s#\./##" | sed "s/.json//" chdir=/etc/elasticsearch/templates
   register: resultstemplate
 
 - name: Install template(s)
-  command: "curl -sL -XPUT http://localhost:{{http_port}}/_template/{{item}} -d @/etc/elasticsearch/templates/{{item}}.json"
+  command: "curl -sL -XPUT http://{{ es_config['network.host'] | default('localost') }}:{{http_port}}/_template/{{item}} -d @/etc/elasticsearch/templates/{{item}}.json"
   with_items: "{{ resultstemplate.stdout_lines }}"

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -171,7 +171,7 @@ case "$1" in
 	fi
 
 	# Start Daemon
-	start-stop-daemon -d $ES_HOME --start -b --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon -d $ES_HOME --start --user "$ES_USER" -c "$ES_USER" --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0


### PR DESCRIPTION
1) When binding elasticsearch to aws local dns entry localhost does not respond and breaks template loading.

2) Also, when there's a jvm error no print out is provided while starting using the init script. by removing the `-b` flag jvm errors are returned on a failed start.

Fixes for both use cases.