### PR TITLE
[WIP] Don't overwrite es_plugins_reinstall but set es_plugins_install instead

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -1,8 +1,8 @@
 ---
 
-# es_plugins_reinstall will be set to true if elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed
+# es_plugins_install will be set to true if elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed or es_plugins_reinstall is explicitly set to true
 # i.e. we have changed ES version(or we have clean installation of ES), or if no plugins listed. Otherwise it is false and requires explicitly setting.
-- set_fact: es_plugins_reinstall={{ ((elasticsearch_install_from_package is defined and elasticsearch_install_from_repo.changed) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) or es_plugins is not defined or es_plugins is none }}
+- set_fact: es_plugins_install={{ ((elasticsearch_install_from_package is defined and elasticsearch_install_from_repo.changed) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) or (es_plugins is defined and not es_plugins is none) or (es_plugins_reinstall is defined and es_plugins_reinstall) }}
 
 - set_fact: list_command="list"
 
@@ -24,7 +24,7 @@
   command: "{{es_home}}/bin/plugin remove {{item}} --silent"
   ignore_errors: yes
   with_items: "{{ installed_plugins.stdout_lines | default([]) }}"
-  when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
+  when: es_plugins_install and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
   notify: restart elasticsearch
   register: plugin_installed
   environment:
@@ -39,7 +39,7 @@
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins | default([]) }}"
-  when: not es_plugins is none and es_plugins_reinstall
+  when: not es_plugins is none and es_plugins_install
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"


### PR DESCRIPTION
When using tags or setting explicitly ``es_plugins_reinstall`` to true in vars, this last is overwrite with a ``set_fact``.

With this PR, we don't overwrite ``es_plugins_reinstall``, but we ``set es_plugins_install`` instead to switch the plugin install.

Here is a related issue #147. See [this](https://github.com/elastic/ansible-elasticsearch/issues/147#issuecomment-245434439) comment for details.