### PR TITLE
Support for Role Mapping

### DIFF
--- a/tasks/xpack/shield/elasticsearch-shield-file.yml
+++ b/tasks/xpack/shield/elasticsearch-shield-file.yml
@@ -60,5 +60,3 @@
   template: src=shield/users_roles.j2 dest={{conf_dir}}/shield/users_roles mode=0644 force=yes
   when: manage_file_users and users_roles | length > 0
 
-#TODO: Support for mapping file
-

--- a/tasks/xpack/shield/elasticsearch-shield.yml
+++ b/tasks/xpack/shield/elasticsearch-shield.yml
@@ -14,7 +14,14 @@
   notify: load-native-realms
   when: (es_enable_xpack and '"shield" in es_xpack_features') and ((es_users is defined and es_users.native is defined) or (es_roles is defined and es_roles.native is defined))
 
-#---------------------------------------------------------------------
+#-----------------------------ROLE MAPPING ----------------------------------------
+
+#Copy Roles files
+- name: Copy role_mapping.yml File for Instance
+  template: src=shield/role_mapping.yml.j2 dest={{conf_dir}}/shield/role_mapping.yml owner={{ es_user }} group={{ es_group }} mode=0644 force=yes
+  when: es_role_mapping is defined
+
+#------------------------------------------------------------------------------------
 
 #Ensure shield conf directory is created
 - name: Ensure shield conf directory exists

--- a/templates/shield/role_mapping.yml.j2
+++ b/templates/shield/role_mapping.yml.j2
@@ -1,0 +1,1 @@
+{{ es_role_mapping | to_nice_yaml }}

--- a/test/integration/helpers/serverspec/xpack_spec.rb
+++ b/test/integration/helpers/serverspec/xpack_spec.rb
@@ -211,5 +211,14 @@ shared_examples 'xpack::init' do |es_version|
     it { should contain 'shield.authc.realms.native1.type: native' }
   end
 
+  #Test contents of role_mapping.yml
+  describe file('/etc/elasticsearch/shield_node/shield/role_mapping.yml') do
+    it { should be_owned_by 'elasticsearch' }
+    it { should contain 'power_user:' }
+    it { should contain '- cn=admins,dc=example,dc=com' }
+    it { should contain 'user:' }
+    it { should contain '- cn=admins,dc=example,dc=com' }
+  end
+
 end
 

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -16,6 +16,12 @@
       - watcher
     es_api_basic_auth_username: es_admin
     es_api_basic_auth_password: changeMe
+    es_role_mapping:
+      power_user:
+        - "cn=admins,dc=example,dc=com"
+      user:
+        - "cn=users,dc=example,dc=com"
+        - "cn=admins,dc=example,dc=com"
     es_users:
       native:
         kibana4_server:


### PR DESCRIPTION
Resolves https://github.com/elastic/ansible-elasticsearch/issues/155

Suports role mapping through new es_role_mapping variable.  Tests include example but will update docs.

Declare in var syntax e.g.

```
es_role_mapping:
      power_user:
        - "cn=admins,dc=example,dc=com"
      user:
        - "cn=users,dc=example,dc=com"
        - "cn=admins,dc=example,dc=com"
```


This gets serialized into the yml file.  No validation so relies on the user.
