### PR TITLE
Activate elasticsearch license and some fixes

### DIFF
--- a/handlers/shield/elasticsearch-shield-native.yml
+++ b/handlers/shield/elasticsearch-shield-native.yml
@@ -64,6 +64,7 @@
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes
   when: manage_native_users and es_users.native.keys() > 0
+  no_log: True
   with_dict: "{{es_users.native}}"
 
 #List current roles

--- a/tasks/xpack/elasticsearch-xpack-activation.yml
+++ b/tasks/xpack/elasticsearch-xpack-activation.yml
@@ -1,4 +1,4 @@
-
+---
 - name: Activate ES license (without shield authentication)
   uri:
     method: PUT
@@ -11,7 +11,7 @@
   when: '"shield" not in es_xpack_features
   failed_when: >
     license_activated.status != 200 or
-    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status is not defined or
     license_activated.json.license_status != 'valid'
 
 - name: Activate ES license (with shield authentication)
@@ -29,7 +29,7 @@
   when: '"shield" in es_xpack_features
   failed_when: >
     license_activated.status != 200 or
-    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status is not defined or
     license_activated.json.license_status != 'valid'
 
 - debug:

--- a/tasks/xpack/elasticsearch-xpack-activation.yml
+++ b/tasks/xpack/elasticsearch-xpack-activation.yml
@@ -1,0 +1,36 @@
+
+- name: Activate ES license (without shield authentication)
+  uri:
+    method: PUT
+    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
+    body_format: json
+    body: "{{ es_xpack_license }}"
+    return_content: yes
+  register: license_activated
+  no_log: True
+  when: '"shield" not in es_xpack_features
+  failed_when: >
+    license_activated.status != 200 or
+    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status != 'valid'
+
+- name: Activate ES license (with shield authentication)
+  uri:
+    method: PUT
+    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
+    user: "{{es_api_basic_auth_username}}"
+    password: "{{es_api_basic_auth_password}}"
+    body_format: json
+    force_basic_auth: yes
+    body: "{{ es_xpack_license }}"
+    return_content: yes
+  register: license_activated
+  no_log: True
+  when: '"shield" in es_xpack_features
+  failed_when: >
+    license_activated.status != 200 or
+    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status != 'valid'
+
+- debug:
+    msg: "License: {{ license_activated.content }}"

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -14,7 +14,7 @@
 #Remove Plugin if installed and its not been requested or the ES version has changed
 - name: Remove {{item}} plugin
   command: >
-    {{es_home}}/bin/plugin remove shield
+    {{es_home}}/bin/plugin remove {{item}}
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -49,7 +49,44 @@
 #Shield configuration
 - include: shield/elasticsearch-shield.yml
 
-#Add any feature specific configuration here
+# Activate ES lience
+- name: Activate ES license (without shield authentication)
+  uri:
+    method: PUT
+    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    body_format: json
+    body: "{{ es_xpack_license }}"
+    return_content: yes
+  register: license_activated
+  no_log: True
+  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack and '"shield" not in es_xpack_features
+  failed_when: >
+    license_activated.status != 200 or
+    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status != 'valid'
 
+- name: Activate ES license (with shield authentication)
+  uri:
+    method: PUT
+    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    user: "{{es_api_basic_auth_username}}"
+    password: "{{es_api_basic_auth_password}}"
+    body_format: json
+    force_basic_auth: yes
+    body: "{{ es_xpack_license }}"
+    return_content: yes
+  register: license_activated
+  no_log: True
+  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack and '"shield" in es_xpack_features
+  failed_when: >
+    license_activated.status != 200 or
+    license_activated.json.license_status is not defined or 
+    license_activated.json.license_status != 'valid'
+
+- debug:
+    msg: "License: {{ license_activated.content }}"
+  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack
+
+#Add any feature specific configuration here
 - name: Set Plugin Directory Permissions
   file: state=directory path={{ es_home }}/plugins owner={{ es_user }} group={{ es_group }} recurse=yes

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -50,42 +50,8 @@
 - include: shield/elasticsearch-shield.yml
 
 # Activate ES lience
-- name: Activate ES license (without shield authentication)
-  uri:
-    method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
-    body_format: json
-    body: "{{ es_xpack_license }}"
-    return_content: yes
-  register: license_activated
-  no_log: True
-  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack and '"shield" not in es_xpack_features
-  failed_when: >
-    license_activated.status != 200 or
-    license_activated.json.license_status is not defined or 
-    license_activated.json.license_status != 'valid'
-
-- name: Activate ES license (with shield authentication)
-  uri:
-    method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
-    user: "{{es_api_basic_auth_username}}"
-    password: "{{es_api_basic_auth_password}}"
-    body_format: json
-    force_basic_auth: yes
-    body: "{{ es_xpack_license }}"
-    return_content: yes
-  register: license_activated
-  no_log: True
-  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack and '"shield" in es_xpack_features
-  failed_when: >
-    license_activated.status != 200 or
-    license_activated.json.license_status is not defined or 
-    license_activated.json.license_status != 'valid'
-
-- debug:
-    msg: "License: {{ license_activated.content }}"
-  when: es_xpack_license is defined and es_xpack_license != '' and es_enable_xpack
+- include: elasticsearch-xpack-activation.yml
+  when: es_enable_xpack and es_xpack_license is defined and es_xpack_license != ''
 
 #Add any feature specific configuration here
 - name: Set Plugin Directory Permissions

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -53,7 +53,7 @@
 - name: Activate ES license (without shield authentication)
   uri:
     method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
     body_format: json
     body: "{{ es_xpack_license }}"
     return_content: yes
@@ -68,7 +68,7 @@
 - name: Activate ES license (with shield authentication)
   uri:
     method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_xpack/license?acknowledge=true"
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
     body_format: json

--- a/tasks/xpack/shield/elasticsearch-shield-file.yml
+++ b/tasks/xpack/shield/elasticsearch-shield-file.yml
@@ -31,6 +31,7 @@
     {{es_home}}/bin/shield/esusers useradd {{item}} -p {{es_users.file[item].password}}
   with_items: "{{users_to_add}}"
   when: manage_file_users and users_to_add | length > 0
+  no_log: True
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_HOME: "{{es_home}}"
@@ -43,6 +44,7 @@
   when: manage_file_users and es_users.file.keys() | length > 0
   #Currently no easy way to figure out if the password has changed or to know what it currently is so we can skip.
   changed_when: False
+  no_log: True
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_HOME: "{{es_home}}"

--- a/test/integration/helpers/serverspec/xpack_spec.rb
+++ b/test/integration/helpers/serverspec/xpack_spec.rb
@@ -87,6 +87,16 @@ shared_examples 'xpack::init' do |es_version|
   describe command('curl -s localhost:9200/_nodes/plugins?pretty=true -u es_admin:changeMe | grep license') do
     its(:exit_status) { should eq 0 }
   end
+  
+  #Test if x-pack is activated
+  describe 'x-pack activation' do
+    it 'should be activated with the license uid '+ENV["ES_XPACK_LICENSE_UID"] do
+      command = command('curl -s localhost:9200/_xpack/license?pretty=true -u es_admin:changeMe')
+      expect(command.stdout).to match(active)
+      expect(command.stdout).to match(ENV["ES_XPACK_LICENSE_UID"])
+      expect(command.exit_status).to eq(0)
+    end
+  end
 
   describe file('/usr/share/elasticsearch/plugins/shield') do
     it { should be_directory }

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -8,6 +8,7 @@
   vars:
     es_templates: true
     es_enable_xpack: true
+    es_xpack_license: <%= ENV['ES_XPACK_LICENSE'] %>
     es_plugins:
       - plugin: lmenezes/elasticsearch-kopf
         version: master

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -5,10 +5,10 @@
     - { role: elasticsearch, es_config: { "http.port": 9200, "transport.tcp.port":9300, discovery.zen.ping.unicast.hosts: "localhost:9300",
     "shield.authc.realms.file1.type": "file","shield.authc.realms.file1.order": 0, "shield.authc.realms.native1.type": "native","shield.authc.realms.native1.order": 1 },
     es_instance_name: "shield_node" }
+  include_vars: <%= ENV['ES_XPACK_LICENSE_FILE'] %>
   vars:
     es_templates: true
     es_enable_xpack: true
-    es_xpack_license: <%= ENV['ES_XPACK_LICENSE'] %>
     es_plugins:
       - plugin: lmenezes/elasticsearch-kopf
         version: master


### PR DESCRIPTION
- We will support xpack soon, so I think we should able to enable xpack by activating the corresponding license by providing `es_xpack_license`
- Don't log user credential on the cli when adding or updating user password
- Fix a typo when removing plugin

@gingerwizard please review and advice :)
