### PR TITLE
Remove old http repo on debian/ubuntu and use https one.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ es_version_lock: false
 es_use_repository: true
 es_apt_key: "https://packages.elasticsearch.org/GPG-KEY-elasticsearch"
 es_apt_url: "deb https://packages.elastic.co/elasticsearch/{{ es_major_version }}/debian stable main"
+es_apt_url_old: "deb http://packages.elastic.co/elasticsearch/{{ es_major_version }}/debian stable main"
 es_start_service: true
 es_java_install: true
 update_java: false

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -14,7 +14,10 @@
   when: es_use_repository and es_apt_key
 
 - name: Debian - Add elasticsearch repository
-  apt_repository: repo="{{ es_apt_url }}" state=present
+  apt_repository: repo={{ item.repo }} state={{ item.state}}
+  with_items:
+    - { repo: "{{ es_apt_url_old }}", state: "absent" }
+    - { repo: "{{ es_apt_url }}", state: "present" }
   when: es_use_repository
 
 - name: Debian - Include versionlock


### PR DESCRIPTION
Fix for the issue introduced with the change in https://github.com/elastic/ansible-elasticsearch/pull/170

Changed debian repo from http to https, but existing http repos (from earlier runs) would persist and lead to an duplicate entry warning in apt.
This PR will remove the old http repo, if present.