### PR TITLE
Use network.host and http.port if available for templates and scripts

### DIFF
--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -4,7 +4,8 @@
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
 - name: Wait for elasticsearch to startup
-  wait_for: port={{es_api_port}} delay=10
+  wait_for: host={% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %} port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
+
 
 - name: Get template files
   find: paths="/etc/elasticsearch/templates" patterns="*.json"
@@ -12,7 +13,7 @@
 
 - name: Install templates without auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     body_format: json
@@ -22,7 +23,7 @@
 
 - name: Install templates with auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -6,7 +6,6 @@
 - name: Wait for elasticsearch to startup
   wait_for: host={% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %} port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
 
-
 - name: Get template files
   find: paths="/etc/elasticsearch/templates" patterns="*.json"
   register: templates

--- a/handlers/shield/elasticsearch-shield-native.yml
+++ b/handlers/shield/elasticsearch-shield-native.yml
@@ -4,7 +4,7 @@
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
 - name: Wait for elasticsearch to startup
-  wait_for: port={{es_api_port}} delay=10
+  wait_for: host={% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %} port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
 
 - set_fact: manage_native_users=false
 
@@ -21,7 +21,7 @@
 #List current users
 - name: List Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user
     method: GET
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
@@ -42,7 +42,7 @@
 #Delete all non required users
 - name: Delete Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user/{{item}}
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user/{{item}}
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -55,7 +55,7 @@
 #Overwrite all other users
 - name: Update Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user/{{item.key}}
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user/{{item.key}}
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"
@@ -70,7 +70,7 @@
 
 - name: List Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role
     method: GET
     body_format: json
     user: "{{es_api_basic_auth_username}}"
@@ -94,7 +94,7 @@
 #Delete all non required roles
 - name: Delete Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role/{{item}}
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role/{{item}}
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -107,7 +107,7 @@
 #Update other roles
 - name: Update Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role/{{item.key}}
+    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role/{{item.key}}
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"
@@ -117,6 +117,3 @@
     force_basic_auth: yes
   when: manage_native_roles and es_roles.native.keys() > 0
   with_dict: "{{es_roles.native}}"
-
-
-


### PR DESCRIPTION
Was causing issues if not bound to localhost and using none default port, as es_api_host/port default to localhost/9200.

@gingerwizard if you got a minute, a review would be nice, as you initially wrote this an I might have missed something.
