### PR TITLE
Remove debug line

### DIFF
--- a/filter_plugins/custom.py
+++ b/filter_plugins/custom.py
@@ -41,4 +41,3 @@ class FilterModule(object):
         'extract_role_users':extract_role_users,
         'filename':filename}
 
-print filename('/etc/elasticsearch/templates/basic.json')


### PR DESCRIPTION
fbfbb66d564e5c1696e2803f2310d5d7d866b6e4 added a debug line at the bottom of the custom.py filter which prints a lot of `basic`.

When this line is removed, the output is normal again.