### PR TITLE
Prevent Ansible errors when shield is not installed/disabled

### DIFF
--- a/tasks/xpack/shield/elasticsearch-shield-file.yml
+++ b/tasks/xpack/shield/elasticsearch-shield-file.yml
@@ -16,7 +16,7 @@
   command: >
     {{es_home}}/bin/shield/esusers userdel {{item}}
   when: manage_file_users and (users_to_remove | length > 0)
-  with_items: "{{users_to_remove}}"
+  with_items: "{{users_to_remove | default([])}}"
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_HOME: "{{es_home}}"
@@ -29,7 +29,7 @@
 - name: Add Users
   command: >
     {{es_home}}/bin/shield/esusers useradd {{item}} -p {{es_users.file[item].password}}
-  with_items: "{{users_to_add}}"
+  with_items: "{{users_to_add | default([])}}"
   when: manage_file_users and users_to_add | length > 0
   environment:
     CONF_DIR: "{{ conf_dir }}"
@@ -39,7 +39,7 @@
 - name: Set User Passwords
   command: >
     {{es_home}}/bin/shield/esusers passwd {{item.key}} -p {{item.value.password}}
-  with_dict: "{{es_users.file}}"
+  with_dict: "{{(es_users | default({'file':{}})).file}}"
   when: manage_file_users and es_users.file.keys() | length > 0
   #Currently no easy way to figure out if the password has changed or to know what it currently is so we can skip.
   changed_when: False


### PR DESCRIPTION
When shield is not installed/disabled, i.e. the _elasticsearch-shield-file.yml_ os not included (due to the `when`-statement), the `with_items` and `with_dict` statements are still evaluated (so Ansible is able to check the `when` for each item in the list/dict).

Unfortunately, the `users_to_remove`, `users_to_add`, and `es_users` variables are not present, so the evaluation of the `with_items` and `with_dict` lists fail.

This PR adds defaults to fix these error situations.

When shield is installed/active the variables are present and the defaults are not used.

Note that I am using Ansible 2.2 (although this issue is also reproducable with ansible 2.1). Maybe Ansible behavior with respect to `include` changed?
