### PR TITLE
Fix issues with systemd service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,10 @@
+- name: reload systemd configuration
+  command: systemctl daemon-reload
 
+# Restart service and ensure it is enabled
 - name: restart elasticsearch
   service: name={{instance_init_script | basename}} state=restarted enabled=yes
-  when: es_restart_on_change and es_start_service and not elasticsearch_started.changed and ((plugin_installed is defined and plugin_installed.changed) or (xpack_state.changed) or (elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed))
+  when: es_restart_on_change and es_start_service and ((plugin_installed is defined and plugin_installed.changed) or (xpack_state.changed) or (elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed))
 
 - name: load-native-realms
   include: ./handlers/shield/elasticsearch-shield-native.yml

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -42,7 +42,9 @@
 - name: Copy Systemd File for Instance
   template: src=systemd/elasticsearch.j2 dest={{instance_sysd_script}} mode=0644 force=yes
   when: use_system_d
-  notify: restart elasticsearch
+  notify:
+  - reload systemd configuration
+  - restart elasticsearch
 
 #Copy the logging.yml
 - name: Copy Logging.yml File for Instance
@@ -63,7 +65,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Delete Default Sysconfig File
-  file: dest=/usr/lib/systemd/system/elasticsearch.service state=absent
+  file: dest="{{ sysd_script }}" state=absent
 
 - name: Delete Default Configuration File
   file: dest=/etc/elasticsearch/elasticsearch.yml state=absent

--- a/tasks/elasticsearch-service.yml
+++ b/tasks/elasticsearch-service.yml
@@ -1,6 +1,0 @@
-# Make sure the service is started, and restart if necessary
-- name: Start elasticsearch service
-  service: name={{instance_init_script | basename}} state=started enabled=yes
-  when: es_start_service
-  register: elasticsearch_started
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,9 +31,6 @@
 - include: xpack/elasticsearch-xpack.yml
   tags:
       - xpack
-- include: elasticsearch-service.yml
-  tags:
-      - service
 - include: elasticsearch-templates.yml
   when: es_templates
   tags:


### PR DESCRIPTION
This PR fixes some issues with the systemd service:

* When service configuration got changed, a `systemctl daemon-reload` is required to refresh the service configuration of systemd
* Do not start the service as task but always use handler. This prevents skipped service restarts when configurations are changed between initial start and the rest of the role.
* Enable service in handler (as the start task is removed). Known issue: the service is not (re)enabled when nothing else changed. I do not think this will ever occur, only situation I can think of, is that the user manually disabled the service and tries to enable it again without changing anything in the configuration/plugins.