### PR TITLE
Fix setting ES_JAVA_OPTS

### DIFF
--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -34,9 +34,7 @@ ES_HEAP_SIZE={{es_heap_size}}
 
 # Additional Java OPTS
 {% if es_java_opts is defined and es_java_opts %}
-{% for java_opt in es_java_opts %}
-ES_JAVA_OPTS="{{java_opt}}"
-{% endfor %}
+ES_JAVA_OPTS="{{es_java_opts | default([]) | join(' ')}}"
 {% else %}
 #ES_JAVA_OPTS=
 {% endif %}


### PR DESCRIPTION
Append all `es_java_opts` instead of adding a new line for each `es_java_opts` list entry.

Original:
```
ES_JAVA_OPTS=opt1
ES_JAVA_OPTS=opt2
ES_JAVA_OPTS=opt3
```

With this patch:
```
ES_JAVA_OPTS=opt1 opt2 op3
```