### PR TITLE
Some fixes for shield related tasks

### DIFF
--- a/handlers/shield/elasticsearch-shield-native.yml
+++ b/handlers/shield/elasticsearch-shield-native.yml
@@ -16,6 +16,10 @@
 - set_fact: manage_native_roles=true
   when: es_roles is defined and es_roles.native is defined
 
+# If playbook runs too fast, Native commands could fail as the Native Realm is not yet up
+- name: Wait 15 seconds for the Native Relm to come up
+  pause: seconds=15
+
 #If the node has just has shield installed it maybe either stopped or started 1. if stopped, we need to start to load native realms 2. if started, we need to restart to load
 
 #List current users

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -18,4 +18,4 @@
 
 - name: Copy scripts to elasticsearch
   copy: src={{ item }} dest={{ es_script_dir }} owner={{ es_user }} group={{ es_group }}
-  with_fileglob: "{{ es_scripts_fileglob }}"
+  with_fileglob: "{{ es_scripts_fileglob | default('') }}"

--- a/tasks/xpack/shield/elasticsearch-shield-file.yml
+++ b/tasks/xpack/shield/elasticsearch-shield-file.yml
@@ -1,6 +1,12 @@
 ---
 - set_fact: manage_file_users=es_users is defined and es_users.file is defined
 
+#Ensure shield conf directory is created
+- name: Ensure shield conf directory exists (file)
+  file: path={{ conf_dir }}/shield state=directory owner={{ es_user }} group={{ es_group }}
+  changed_when: False
+  when: es_enable_xpack and '"shield" in es_xpack_features'
+
 #List current users
 - name: List Users
   shell: cat {{conf_dir}}/shield/users | awk -F':' '{print $1}'
@@ -60,3 +66,6 @@
   template: src=shield/users_roles.j2 dest={{conf_dir}}/shield/users_roles mode=0644 force=yes
   when: manage_file_users and users_roles | length > 0
 
+#Set permission on shield directory. E.g. if 2 nodes are installed on the same machine, the second node will not get the users file created at install, causing the files being created at es_users call and then having the wrong Permissions.
+- name: Set Shield Directory Permissions Recursive
+  file: state=directory path={{conf_dir}}/shield/ owner={{ es_user }} group={{ es_group }} recurse=yes


### PR DESCRIPTION
Should make https://github.com/elastic/ansible-elasticsearch/issues/167 work.

Added a 15 sec pause before the Native User List command.
Command was run when the realm was not initialized yet, causing the playbook to fail.

Added default value to es_scripts_fileglob. Could fail if undefined.
Closes #187

When a second node is installed, the shield directory and the user* files are not automatically created.
This could cause the role to fail.
- Added check to that shield directory exists
- Added chown -R for the shield directory, as user* files created by the esusers command, belonged to the user ansible is running as.