### PR TITLE
Add retries for install plugins task

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -45,6 +45,9 @@
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
+  until: plugin_installed.rc == 0
+  retries: 5
+  delay: 5
 
 #Set permissions on plugins directory
 - name: Set Plugin Directory Permissions


### PR DESCRIPTION
When you install a large number of plugins and unstable network - a problem to install a plugin causes a problem in the performance of ansible-playbook.
In this case - the plugin was successfully installed on the second or third run ansible-playbook.

I want to get away from this problem, and make several attempts to install the plugin if it did not happen on the first try.