### PR TITLE
Install EPEL and python-pip on Red Hat Family OS

### DIFF
--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -24,6 +24,13 @@
   when: not es_use_repository
   register: elasticsearch_install_from_package
 
+#Install EPEL repository first to be able to install python-pip afterwards
+- name: Install EPEL
+  yum: name=http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm state=present update_cache=yes
+
+- name: Install python-pip
+  yum: name=python-pip state=present update_cache=yes
+
 # ansible uri module requires python-httplib2
 - name: python-httplib2
   pip: name=httplib2


### PR DESCRIPTION
When on a Red Hat family OS, there's a problem with this task:

# ansible uri module requires python-httplib2
- name: python-httplib2
pip: name=httplib2

It fails if pip is not installed on the system before running this ansible-elasticsearch role.

Solution:

1) Intall EPEL (repository that contains pip)
2) Install python-pip
3) Install httplib2
