### PR TITLE
Remove httplib2

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -37,7 +37,3 @@
   apt: deb=/tmp/elasticsearch-{{ es_version }}.deb
   when: not es_use_repository
   register: elasticsearch_install_from_package
-
-# ansible uri module requires httplib2
-- name: python-httplib2
-  apt: name=python-httplib2

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -23,7 +23,3 @@
   yum: name={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.noarch.rpm{% endif %} state=present
   when: not es_use_repository
   register: elasticsearch_install_from_package
-
-# ansible uri module requires python-httplib2
-- name: python-httplib2
-  pip: name=httplib2


### PR DESCRIPTION
The dependency on httplib2 was removed in Ansible 2.1

Resolves #161 