### PR TITLE
Add binary prefix for version 5.x

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -13,7 +13,7 @@
 - set_fact: es_binary_prefix=""
 
 - set_fact: es_binary_prefix="elasticsearch-"
-  when: es_version | version_compare('2.0', '>')
+  when: es_version | version_compare('5.0', '>=')
 
 #List currently installed plugins - ignore xpack if > v 2.0
 - name: Check installed elasticsearch plugins

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -10,8 +10,14 @@
 - set_fact: list_command="--list"
   when: es_version | version_compare('2.0', '<')
 
+- set_fact: es_binary_prefix=""
+
+- set_fact: es_binary_prefix="elasticsearch-"
+  when: es_version | version_compare('2.0', '>')
+
 #List currently installed plugins - ignore xpack if > v 2.0
-- shell: "{{es_home}}/bin/plugin {{list_command}} | sed -n '1!p' | cut -d '-' -f2-{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"
+- name: Check installed elasticsearch plugins
+  shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin {{list_command}}{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"
   register: installed_plugins
   failed_when: "'ERROR' in installed_plugins.stdout"
   changed_when: False
@@ -20,22 +26,21 @@
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
 
-#This needs to removes any currently installed plugins
+# This removes any currently installed plugins (to prevent errors when reinstalling)
 - name: Remove elasticsearch plugins
-  command: "{{es_home}}/bin/plugin remove {{item}} --silent"
+  command: "{{es_home}}/bin/{{ es_binary_prefix }}plugin remove {{item}} --silent"
   ignore_errors: yes
   with_items: "{{ installed_plugins.stdout_lines | default([]) }}"
   when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
   notify: restart elasticsearch
-  register: plugin_installed
+  register: plugin_removed
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
-  #debug: var=item
   command: >
-    {{es_home}}/bin/plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %} {% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %} --silent
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %} {% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %} --silent
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -10,11 +10,6 @@
 - set_fact: list_command="--list"
   when: es_version | version_compare('2.0', '<')
 
-- set_fact: es_binary_prefix=""
-
-- set_fact: es_binary_prefix="elasticsearch-"
-  when: es_version | version_compare('5.0', '>=')
-
 #List currently installed plugins - ignore xpack if > v 2.0
 - name: Check installed elasticsearch plugins
   shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin {{list_command}}{% if es_version | version_compare('5.0', '<') %} | sed -n '1!p' | cut -d '-' -f2-{% endif %}{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -17,7 +17,7 @@
 
 #List currently installed plugins - ignore xpack if > v 2.0
 - name: Check installed elasticsearch plugins
-  shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin {{list_command}}{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"
+  shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin {{list_command}}{% if es_version | version_compare('5.0', '<') %} | sed -n '1!p' | cut -d '-' -f2-{% endif %}{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"
   register: installed_plugins
   failed_when: "'ERROR' in installed_plugins.stdout"
   changed_when: False

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,5 +1,10 @@
 ---
 
+- set_fact: es_binary_prefix=""
+
+- set_fact: es_binary_prefix="elasticsearch-"
+  when: es_version | version_compare('5.0', '>=')
+
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
   include: elasticsearch-optional-user.yml

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -1,7 +1,7 @@
 ---
 
 #Test if feature is installed
-- shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin list | sed -n '1!p' | grep {{item}}"
+- shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin list{% if es_version | version_compare('5.0', '<') %} | sed -n '1!p' | cut -d '-' -f2-{% endif %} | grep {{item}}"
   register: feature_installed
   changed_when: False
   failed_when: "'ERROR' in feature_installed.stdout"

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -1,7 +1,7 @@
 ---
 
 #Test if feature is installed
-- shell: "{{es_home}}/bin/plugin list | sed -n '1!p' | grep {{item}}"
+- shell: "{{es_home}}/bin/{{ es_binary_prefix }}plugin list | sed -n '1!p' | grep {{item}}"
   register: feature_installed
   changed_when: False
   failed_when: "'ERROR' in feature_installed.stdout"
@@ -14,7 +14,7 @@
 #Remove Plugin if installed and its not been requested or the ES version has changed
 - name: Remove {{item}} plugin
   command: >
-    {{es_home}}/bin/plugin remove shield
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin remove shield
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0
@@ -28,7 +28,7 @@
 #Install plugin if not installed, or the es version has changed (so removed above), and its been requested
 - name: Install {{item}} plugin
   command: >
-    {{es_home}}/bin/plugin install {{item}}
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin install {{item}}
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -7,7 +7,7 @@
 #Check if license is installed
 - name: Check License is installed
   shell: >
-    {{es_home}}/bin/plugin list | tail -n +2 | grep license
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin list | tail -n +2 | grep license
   register: license_installed
   ignore_errors: yes
   failed_when: "'ERROR' in license_installed.stdout"
@@ -19,7 +19,7 @@
 #Remove license if installed and xpack not enabled
 - name: Remove license plugin
   command: >
-    {{es_home}}/bin/plugin remove license
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin remove license
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0
@@ -32,7 +32,7 @@
 #Install License if not installed, or it needs to be reinstalled due to ES change (above task will have removed), and its been requested.
 - name: Install license plugin
   command: >
-    {{es_home}}/bin/plugin install license
+    {{es_home}}/bin/{{ es_binary_prefix }}plugin install license
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0


### PR DESCRIPTION
As requested in #182 a PR for the 5.x branch.

Copied from #178:

The `plugin` executable for Elasticsearch version 5.0.0, is renamed `elasticsearch-plugin`.

This PR uses the new executable name when `es_version` indicates that version 5 (or higher) is used.

Some other minor plugin-related changes:

* Removed `sed -n '1!p' | cut -d '-' -f2-` as the executable just returns a list of installed plugins (or is this also new in version 5.x?)
* Added task name for 'installed plugins check'
* Result of 'remove plugins' task is stored in `plugin_removed`

Note that I have updated the xpack/* files as well, but this is untested. Since it also contains some shell filters (`tail -n +2`), I would assume it does not work with version 5 as well...