### PR TITLE
Only use es_api_host in API calls since es_config['network.host'] is not a reliable source

### DIFF
--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -3,8 +3,41 @@
 - name: Ensure elasticsearch is started
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
+- set_fact:
+    es_config_host: "{{ item }}"
+  with_items: "{{ es_config['network.host'] }}"
+  when: 
+    - es_config['network.host'] is defined and es_config['network.host'] is not string
+    - not item | match('^_.*_$')
+    - es_config_host is not defined
+  
+- set_fact:
+    es_config_host: "{{ es_config['network.host'] }}"
+  when: 
+    - es_config['network.host'] is defined and es_config['network.host'] is string
+    - not es_config['network.host'] | match('^_.*_$')
+
+- set_fact:
+    es_config_port: "{{ es_config['network.port'] }}"
+  when: 
+    - es_config['network.port'] is defined and es_config['network.port'] is number
+
+- set_fact:
+    es_config_port: "{{ es_config['network.port'].split('-').0 }}"
+  when: 
+    - es_config['network.port'] is defined and es_config['network.port'] is string
+    - es_config['network.port'] | match('^\d')
+
 - name: Wait for elasticsearch to startup
-  wait_for: host="{{es_api_host}}" port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
+  wait_for:
+    host: "{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}"
+    port: "{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}" 
+    delay: 10
+
+- name: Gather template files contents
+  shell: "cat /etc/elasticsearch/templates/{{ item }}"
+  with_items: "{{ es_template_files }}"
+  register: es_template_files_contents
 
 - name: Get template files
   find: paths="/etc/elasticsearch/templates" patterns="*.json"
@@ -12,7 +45,7 @@
 
 - name: Install templates without auth
   uri:
-    url: "http://{{es_api_host}}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}:{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     body_format: json
@@ -22,7 +55,7 @@
 
 - name: Install templates with auth
   uri:
-    url: "http://{{es_api_host}}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}:{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -49,9 +49,9 @@
     method: PUT
     status_code: 200
     body_format: json
-    body: "{{ lookup('file', item.path) }}"
+    body: "{{ item.stdout }}"
   when: not es_enable_xpack or not es_xpack_features is defined or not '"shield" in es_xpack_features'
-  with_items: "{{ templates.files }}"
+  with_items: "{{ es_template_files_contents.results }}"
 
 - name: Install templates with auth
   uri:
@@ -62,6 +62,6 @@
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes
     body_format: json
-    body: "{{ lookup('file', item.path) }}"
+    body: "{{ item.stdout }}"
   when: es_enable_xpack and es_xpack_features is defined and '"shield" in es_xpack_features'
-  with_items: "{{ templates.files }}"
+  with_items: "{{ es_template_files_contents.results }}"

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -4,7 +4,7 @@
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
 - name: Wait for elasticsearch to startup
-  wait_for: host={% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %} port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
+  wait_for: host="{{es_api_host}}" port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
 
 - name: Get template files
   find: paths="/etc/elasticsearch/templates" patterns="*.json"
@@ -12,7 +12,7 @@
 
 - name: Install templates without auth
   uri:
-    url: "http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     body_format: json
@@ -22,7 +22,7 @@
 
 - name: Install templates with auth
   uri:
-    url: "http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"


### PR DESCRIPTION
Sticking with the `es_api_host` as the only variable to use for the host in API calls, etc.  `es_api_host ` defaults to `localhost` which is a good default since many elasticsearch configs set `_local_` in `network.host`.