### PR TITLE
added ES_JVM_OPTIONS to systemd template

### DIFF
--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -10,6 +10,7 @@ Environment=CONF_DIR={{conf_dir}}
 Environment=DATA_DIR={{ data_dirs | array_to_str }}
 Environment=LOG_DIR={{log_dir}}
 Environment=PID_DIR={{pid_dir}}
+Environment=ES_JVM_OPTIONS={{conf_dir}}/jvm.options
 EnvironmentFile=-{{instance_default_file}}
 
 WorkingDirectory={{es_home}}


### PR DESCRIPTION
You need to set ES_JVM_OPTIONS to point to the jvm.options file since default is /etc/elasticsearch/.
For installations with multiple roles on single nodes, the jvm.options can go in each roles config directory.
ex. /etc/elasticsearch/master/jvm.options

source: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_packaging.html#_jvm_options