### PR TITLE
Updated yum repository URL for 5.x

### DIFF
--- a/templates/elasticsearch.repo
+++ b/templates/elasticsearch.repo
@@ -1,6 +1,8 @@
 [elasticsearch-{{ es_major_version }}]
 name=Elasticsearch repository for {{ es_major_version }} packages
-baseurl=http://packages.elastic.co/elasticsearch/{{ es_major_version }}/centos
+baseurl={% if es_version | version_compare('5.0', '>=') %}https://artifacts.elastic.co/packages/{{ es_major_version }}/yum{% else %}http://packages.elastic.co/elasticsearch/{{ es_major_version }}/centos{% endif %}
+
 gpgcheck=1
-gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+gpgkey={% if es_version | version_compare('5.0', '>=') %}https://artifacts.elastic.co/GPG-KEY-elasticsearch{% else %}http://packages.elastic.co/GPG-KEY-elasticsearch{% endif %}
+
 enabled=1


### PR DESCRIPTION
While trying the role on a CentOS 7 box to install Elasticsearch 5.x, I came across this little issue and fixed it. In a nutshell, the `baseurl` (and `gpgkey`) properties in `templates/elasticsearch.repo` don't work with 5.x. This is simply because the repository base URL has changed (see for example <https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-repositories.html#_yum_dnf> vs. <https://www.elastic.co/guide/en/elasticsearch/reference/5.0/rpm.html>). This PR changes the URL for 5.x while retaining backwards compatibility - older versions will still get installed from their respective repositories. In my own tests, this seemed to work fine for both 2.x and 5.x. 