### PR TITLE
set ES_JVM_OPTIONS so that the startup script will read the jvm.optio…

### DIFF
--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -8,6 +8,9 @@ ES_HOME={{es_home}}
 # Elasticsearch configuration directory
 CONF_DIR={{conf_dir}}
 
+# Elasticsearch jvm options file
+ES_JVM_OPTIONS={{conf_dir}}/jvm.options
+
 # Elasticsearch data directory
 DATA_DIR={{ data_dirs | array_to_str }}
 

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -116,6 +116,7 @@ export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
+export ES_JVM_OPTIONS
 export ES_GC_LOG_FILE
 export JAVA_HOME
 

--- a/templates/init/redhat/elasticsearch.j2
+++ b/templates/init/redhat/elasticsearch.j2
@@ -63,6 +63,7 @@ export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
+export ES_JVM_OPTIONS
 export ES_GC_LOG_FILE
 export ES_STARTUP_SLEEP_TIME
 export JAVA_HOME


### PR DESCRIPTION
The startup `script /usr/share/elasticsearch/bin/elasticsearch` wasn't able to start elasticsearch with the options defined in jvm.options because the env variable `ES_JVM_OPTIONS` was not defined.
I defined the variable in the config file inside `/etc/sysconfig` and exported it in the `init.d` script