### PR TITLE
Use elasticsearch_plugin instead of the current shell/command modules

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -1,47 +1,15 @@
 ---
-
-# es_plugins_reinstall will be set to true if elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed
-# i.e. we have changed ES version(or we have clean installation of ES), or if no plugins listed. Otherwise it is false and requires explicitly setting.
-- set_fact: es_plugins_reinstall=true
-  when: ((elasticsearch_install_from_repo is defined and elasticsearch_install_from_repo.changed) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) or es_plugins is not defined or es_plugins is none
-
-- set_fact: list_command="list"
-
-- set_fact: list_command="--list"
-  when: es_version | version_compare('2.0', '<')
-
-#List currently installed plugins - ignore xpack if > v 2.0
-- shell: "{{es_home}}/bin/plugin {{list_command}} | sed -n '1!p' | cut -d '-' -f2-{% if es_version | version_compare('2.0', '>') %} | grep -vE '{{supported_xpack_features | join('|')}}|license'{% endif %}"
-  register: installed_plugins
-  failed_when: "'ERROR' in installed_plugins.stdout"
-  changed_when: False
-  ignore_errors: yes
-  environment:
-    CONF_DIR: "{{ conf_dir }}"
-    ES_INCLUDE: "{{ instance_default_file }}"
-
-#This needs to removes any currently installed plugins
-- name: Remove elasticsearch plugins
-  command: "{{es_home}}/bin/plugin remove {{item}} --silent"
-  ignore_errors: yes
-  with_items: "{{ installed_plugins.stdout_lines | default([]) }}"
-  when: es_plugins_reinstall and installed_plugins.stdout_lines | length > 0 and not 'No plugin detected' in installed_plugins.stdout_lines[0]
+- name: Ensure defined ES plugins are installed
+  elasticsearch_plugin:
+    name: "{{ item.plugin }}"
+    version: "{{ item.version | default(omit) }}"
+    proxy_host: "{{ item.proxy_host | default(omit) }}"
+    proxy_port: "{{ item.proxy_port | default(omit) }}"
+    plugin_dir: "{{ es_home }}/plugins"
+    plugin_bin: "{{ es_home }}/bin/plugin"
   notify: restart elasticsearch
   register: plugin_installed
-  environment:
-    CONF_DIR: "{{ conf_dir }}"
-    ES_INCLUDE: "{{ instance_default_file }}"
-
-- name: Install elasticsearch plugins
-  #debug: var=item
-  command: >
-    {{es_home}}/bin/plugin install {{ item.plugin }}{% if item.version is defined and item.version != '' %}/{{ item.version }}{% endif %} {% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %} --silent
-  register: plugin_installed
-  failed_when: "'ERROR' in plugin_installed.stdout"
-  changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins | default([]) }}"
-  when: not es_plugins is none and es_plugins_reinstall
-  notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -6,6 +6,7 @@
   changed_when: False
   failed_when: "'ERROR' in feature_installed.stdout"
   ignore_errors: yes
+  check_mode: False
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -12,6 +12,7 @@
   ignore_errors: yes
   failed_when: "'ERROR' in license_installed.stdout"
   changed_when: False
+  check_mode: False
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"


### PR DESCRIPTION
The current way that elasticsearch plugins are installed caused our internal tests to fail idempotency when using this role.

I've migrated to using elasticsearch_plugin, which locks anyone down to using only Ansible >2.x, but I figure its 'modern,' but may break backwards-compatibility for those using an old ansible install.