### PR TITLE
Use api_host and api_port + removal of tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,14 +22,6 @@ platforms:
         - apt-get update && apt-get install -y software-properties-common &&  add-apt-repository -y ppa:ansible/ansible
         - apt-get update && apt-get -y -q install python-apt python-pycurl
       use_sudo: false
-  - name: debian-7
-    driver_config:
-      image: dliappis/debian-devopsci:7
-      privileged: true
-      provision_command:
-        - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml
-        - apt-get install -y -q net-tools
-      use_sudo: false
   - name: debian-8
     driver_config:
       image: dliappis/debian-devopsci:8
@@ -43,12 +35,6 @@ platforms:
         - sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
       use_sudo: false
       run_command: "/sbin/init"
-  - name: centos-6
-    driver_config:
-      image: dliappis/centos-devopsci:6
-      privileged: true
-      provision_command:
-      use_sudo: false
   - name: centos-7
     driver_config:
       image: dliappis/centos-devopsci:7
@@ -90,48 +76,6 @@ suites:
         es_plugins:
           - plugin: lmenezes/elasticsearch-kopf
             version: master
-    provisioner:
-      playbook: test/integration/multi.yml
-  - name: standard-1x
-    provisioner:
-      playbook: test/integration/standard.yml
-    run_list:
-    attributes:
-      extra_vars:
-        es_major_version: 1.7
-        es_version: 1.7.3
-  - name: package-1x
-    run_list:
-    attributes:
-      extra_vars:
-        es_major_version: 1.7
-        es_version: 1.7.3
-        es_plugins:
-          - plugin: lmenezes/elasticsearch-kopf
-            version: master
-          - plugin: elasticsearch/marvel
-            version: latest
-    provisioner:
-      playbook: test/integration/package.yml
-  - name: config-1x
-    run_list:
-    attributes:
-      extra_vars:
-        es_major_version: 1.7
-        es_version: 1.7.3
-    provisioner:
-      playbook: test/integration/config.yml
-  - name: multi-1x
-    run_list:
-    attributes:
-      extra_vars:
-        es_major_version: 1.7
-        es_version: 1.7.3
-        es_plugins:
-          - plugin: lmenezes/elasticsearch-kopf
-            version: master
-          - plugin: elasticsearch/marvel
-            version: latest
     provisioner:
       playbook: test/integration/multi.yml
   - name: xpack-2x

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,6 +37,7 @@ platforms:
       provision_command:
         - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml curl wget
         - apt-get install -y -q net-tools
+        - apt-get install -y ansible
         - sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
         - sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
         - sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,12 @@ platforms:
         - sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
       use_sudo: false
       run_command: "/sbin/init"
+  - name: centos-6
+    driver_config:
+      image: dliappis/centos-devopsci:6
+      privileged: true
+      provision_command:
+      use_sudo: false
   - name: centos-7
     driver_config:
       image: dliappis/centos-devopsci:7

--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 Ansible role for Elasticsearch.  Currently this works on Debian and RedHat based linux systems.  Tested platforms are:
 
 * Ubuntu 14.04
-* Debian 7
 * Debian 8
-* Centos 6
 * Centos 7
 
-The latest Elasticsearch versions of 1.7.x and 2.x are actively tested.  **Only Ansible versions > 2.1.2 are supported.**
+The latest Elasticsearch versions of 2.x are actively tested.  **Only Ansible versions > 2.1.2 are supported.**. 5.x will be available shortly.
 
 ## Usage
 
@@ -75,7 +73,7 @@ The following illustrates applying configuration parameters to an Elasticsearch 
     es_heap_size: 1g
 ```
 `
-The role utilises Elasticsearch version defaults.  Multicast is therefore enabled for 1.x and disabled for 2.x (plugin required in 2.x).  If using 1.x it is strongly recommended you disable
+The role utilises Elasticsearch version defaults.  Multicast is therefore enabled for 1.x (legacy) and disabled for 2.x (plugin required in 2.x).  If using 1.x it is strongly recommended you disable
 multicast and specify the required uni-cast settings for a production environment. 
 When not utilizing multicast, the following should be set to ensure a successful cluster forms.
 
@@ -127,6 +125,11 @@ A more complex example:
           proxy_host: proxy.example.com
           proxy_port: 8080
 ```
+
+#### Important Note
+
+The role uses es_api_host and es_api_port to communicate with the node for actions only achievable via http e.g. to install templates.  These default to "localhost" and 9200 respectively.  
+If the node is deployed to bind on either a different host or port, these must be changed.
 
 ### Multi Node Server Installations
 
@@ -212,8 +215,10 @@ Additional parameters to es_config allow the customization of the Java and Elast
 
 Following variables affect the versions installed:
 
-* ```es_major_version``` (e.g. "1.5" ). Should be consistent with es_version. For versions >= 2.0 this must be "2.x".
-* ```es_version``` (e.g. "1.5.2").  
+* ```es_major_version``` (e.g. "2.4" ). Should be consistent with es_version. For versions >= 2.0 this must be "2.x".
+* ```es_version``` (e.g. "2.4.2").  
+* ```es_api_host``` The host name used for actions requiring HTTP e.g. installing templates. Defaults to "localhost".
+* ```es_api_port``` The port used for actions requiring HTTP e.g. installing templates. Defaults to 9200.
 * ```es_start_service``` (true (default) or false)
 * ```es_plugins_reinstall``` (true or false (default) )
 * ```es_plugins``` an array of plugin definitions e.g.:
@@ -235,7 +240,6 @@ Earlier examples illustrate the installation of plugins for 2.x.  The correct us
  
  - 2.x. - For officially supported plugins no version or source delimiter is required. The plugin script will determine the appropriate plugin version based on the target Elasticsearch version.  
  For community based plugins include the full path e.g. "lmenezes/elasticsearch-kopf" and the appropriate version for the target version of Elasticsearch.
- - 1.x - Full path and version is required for both community and official plugins e.g. "elasticsearch/marvel"
  
 If installing Marvel or Watcher, ensure the license plugin is also specified.  Shield configuration is currently not supported but planned for later versions.
 

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -16,7 +16,7 @@
     method: PUT
     status_code: 200
     body_format: json
-    body: "{{ item.stdout }}"
+    body: "{{ lookup('file', item.path) }}"
   when: not es_enable_xpack or not es_xpack_features is defined or not '"shield" in es_xpack_features'
   with_items: "{{ templates.files }}"
 
@@ -29,6 +29,6 @@
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes
     body_format: json
-    body: "{{ item.stdout }}"
+    body: "{{ lookup('file', item.path) }}"
   when: es_enable_xpack and es_xpack_features is defined and '"shield" in es_xpack_features'
   with_items: "{{ templates.files }}"

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -3,41 +3,8 @@
 - name: Ensure elasticsearch is started
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
-- set_fact:
-    es_config_host: "{{ item }}"
-  with_items: "{{ es_config['network.host'] }}"
-  when: 
-    - es_config['network.host'] is defined and es_config['network.host'] is not string
-    - not item | match('^_.*_$')
-    - es_config_host is not defined
-  
-- set_fact:
-    es_config_host: "{{ es_config['network.host'] }}"
-  when: 
-    - es_config['network.host'] is defined and es_config['network.host'] is string
-    - not es_config['network.host'] | match('^_.*_$')
-
-- set_fact:
-    es_config_port: "{{ es_config['network.port'] }}"
-  when: 
-    - es_config['network.port'] is defined and es_config['network.port'] is number
-
-- set_fact:
-    es_config_port: "{{ es_config['network.port'].split('-').0 }}"
-  when: 
-    - es_config['network.port'] is defined and es_config['network.port'] is string
-    - es_config['network.port'] | match('^\d')
-
 - name: Wait for elasticsearch to startup
-  wait_for:
-    host: "{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}"
-    port: "{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}" 
-    delay: 10
-
-- name: Gather template files contents
-  shell: "cat /etc/elasticsearch/templates/{{ item }}"
-  with_items: "{{ es_template_files }}"
-  register: es_template_files_contents
+  wait_for: host={{es_api_host}} port={{es_api_port}} delay=10
 
 - name: Get template files
   find: paths="/etc/elasticsearch/templates" patterns="*.json"
@@ -45,17 +12,17 @@
 
 - name: Install templates without auth
   uri:
-    url: "http://{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}:{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     body_format: json
     body: "{{ item.stdout }}"
   when: not es_enable_xpack or not es_xpack_features is defined or not '"shield" in es_xpack_features'
-  with_items: "{{ es_template_files_contents.results }}"
+  with_items: "{{ templates.files }}"
 
 - name: Install templates with auth
   uri:
-    url: "http://{% if es_config_host is defined %}{{es_config_host}}{% else %}{{es_api_host}}{% endif %}:{% if es_config_port is defined %}{{es_config_port}}{% else %}{{es_api_port}}{% endif %}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -64,4 +31,4 @@
     body_format: json
     body: "{{ item.stdout }}"
   when: es_enable_xpack and es_xpack_features is defined and '"shield" in es_xpack_features'
-  with_items: "{{ es_template_files_contents.results }}"
+  with_items: "{{ templates.files }}"

--- a/handlers/shield/elasticsearch-shield-native.yml
+++ b/handlers/shield/elasticsearch-shield-native.yml
@@ -4,7 +4,7 @@
   service: name={{instance_init_script | basename}} state=started enabled=yes
 
 - name: Wait for elasticsearch to startup
-  wait_for: host={% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %} port={% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %} delay=10
+  wait_for: host={{es_api_host}} port={{es_api_port}} delay=10
 
 - set_fact: manage_native_users=false
 
@@ -25,7 +25,7 @@
 #List current users
 - name: List Native Users
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user
     method: GET
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
@@ -46,7 +46,7 @@
 #Delete all non required users
 - name: Delete Native Users
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user/{{item}}
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user/{{item}}
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -59,7 +59,7 @@
 #Overwrite all other users
 - name: Update Native Users
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/user/{{item.key}}
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/user/{{item.key}}
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"
@@ -74,7 +74,7 @@
 
 - name: List Native Roles
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role
     method: GET
     body_format: json
     user: "{{es_api_basic_auth_username}}"
@@ -98,7 +98,7 @@
 #Delete all non required roles
 - name: Delete Native Roles
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role/{{item}}
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role/{{item}}
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -111,7 +111,7 @@
 #Update other roles
 - name: Update Native Roles
   uri:
-    url: http://{% if es_config['network.host'] is defined %}{{es_config['network.host']}}{% else %}{{es_api_host}}{% endif %}:{% if es_config['http.port'] is defined %}{{es_config['http.port']}}{% else %}{{es_api_port}}{% endif %}/_shield/role/{{item.key}}
+    url: http://{{es_api_host}}:{{es_api_port}}/_shield/role/{{item.key}}
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -25,7 +25,7 @@
   when: es_version_lock
 
 - name: Debian - Ensure elasticsearch is installed
-  apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present force={{force_install}} allow_unauthenticated={{ 'false' if es_apt_key else 'true' }} cache_valid_time=86400
+  apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present force={{force_install}} allow_unauthenticated={{ 'no' if es_apt_key else 'yes' }} cache_valid_time=86400
   when: es_use_repository
   register: elasticsearch_install_from_repo
 


### PR DESCRIPTION
Merges https://github.com/elastic/ansible-elasticsearch/pull/209 with additional fixes for loading templates. Reverts https://github.com/elastic/ansible-elasticsearch/commit/5212c6eb4c84b04b36f5850740809d26d6658c16#diff-7f25ff5bf33de039104c5c59d1709488 and adds additional docs

Removes support for centos 6 and debian 7 testing and 1.x