### PR TITLE
quote interpolated variables in command

### DIFF
--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -13,7 +13,7 @@
 
 #Remove Plugin if installed and its not been requested or the ES version has changed
 - name: Remove {{item}} plugin
-  command: {{es_home}}/bin/plugin remove {{item}}
+  command: "{{es_home}}/bin/plugin remove {{item}}"
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0


### PR DESCRIPTION
Ansible 2.2.0 will barf when it hits this task.  It complains about the syntax of unquoted variable. 

The error

```
TASK [elasticsearch : include] *************************************************
fatal: [127.0.0.1]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/vagrant/ansible/roles/elasticsearch/tasks/xpack/elasticsearch-xpack-install.yml': line 16, column 23, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Remove {{item}} plugin\n  command: {{es_home}}/bin/plugin remove {{item}}\n                      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
fatal: [127.0.0.1]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/vagrant/ansible/roles/elasticsearch/tasks/xpack/elasticsearch-xpack-install.yml': line 16, column 23, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Remove {{item}} plugin\n  command: {{es_home}}/bin/plugin remove {{item}}\n                      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
fatal: [127.0.0.1]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/vagrant/ansible/roles/elasticsearch/tasks/xpack/elasticsearch-xpack-install.yml': line 16, column 23, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Remove {{item}} plugin\n  command: {{es_home}}/bin/plugin remove {{item}}\n                      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
fatal: [127.0.0.1]: FAILED! => {"failed": true, "reason": "Syntax Error while loading YAML.\n\n\nThe error appears to have been in '/vagrant/ansible/roles/elasticsearch/tasks/xpack/elasticsearch-xpack-install.yml': line 16, column 23, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- name: Remove {{item}} plugin\n  command: {{es_home}}/bin/plugin remove {{item}}\n                      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```