### PR TITLE
Adding proxy support for yum repo

### DIFF
--- a/templates/elasticsearch.repo
+++ b/templates/elasticsearch.repo
@@ -4,3 +4,7 @@ baseurl=https://artifacts.elastic.co/packages/{{ es_major_version }}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1
+{% if es_proxy_host is defined and es_proxy_port is defined %}
+proxy=http://{{ es_proxy_host }}:{{es_proxy_port}}
+{% endif %}
+


### PR DESCRIPTION
this commit adds support for the `proxy` setting in the yum repo definition. It reuses `es_proxy_host` and `es_proxy_port` from main configuration