### PR TITLE
Add condition to enable jmx-monitoring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,4 @@ pid_dir: ''
 log_dir: ''
 conf_dir: ''
 data_dirs: ''
-jmx_remote_monitoring_enabled: true
+jmx_remote_monitoring_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,4 @@ pid_dir: ''
 log_dir: ''
 conf_dir: ''
 data_dirs: ''
+jmx_remote_monitoring_enabled: true

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -106,3 +106,6 @@
 # WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
 # only for migration purposes.
 #-Delasticsearch.json.allow_unquoted_field_names=true
+{% if jmx_remote_monitoring_enabled == true %}
+-Dcom.sun.management.jmxremote
+{% endif %}


### PR DESCRIPTION
This one needs to enable JMX RMI monitoring for JVM. It's intended to use with prometheus jmx exporter through a local connection.