### PR TITLE
Ability to add custom jvm options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,5 @@ pid_dir: ''
 log_dir: ''
 conf_dir: ''
 data_dirs: ''
+# JMX remote monitoring
+jmx_remote_monitoring_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,5 +36,5 @@ pid_dir: ''
 log_dir: ''
 conf_dir: ''
 data_dirs: ''
-# JMX remote monitoring
-jmx_remote_monitoring_enabled: true
+# JVM custom parameters
+es_jvm_custom_parameters: ''

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -107,9 +107,5 @@
 # only for migration purposes.
 #-Delasticsearch.json.allow_unquoted_field_names=true
 {% if jmx_remote_monitoring_enabled == true %}
-#-Dcom.sun.management.jmxremote.port={{ jmx_remote_monitoring_port }}
-#-Dcom.sun.management.jmxremote.authenticate={{ jmx_remote_monitoring_auth }}
-#-Dcom.sun.management.jmxremote.ssl={{ jmx_remote_monitoring_ssl }}
-##-Djava.rmi.server.hostname="127.0.0.1"
 -Dcom.sun.management.jmxremote
 {% endif %}

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -106,6 +106,8 @@
 # WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
 # only for migration purposes.
 #-Delasticsearch.json.allow_unquoted_field_names=true
-{% if jmx_remote_monitoring_enabled == true %}
--Dcom.sun.management.jmxremote
+{% if es_jvm_custom_parameters !='' %}
+{% for item in es_jvm_custom_parameters %}
+{{ item }}
+{% endfor %}
 {% endif %}

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -106,3 +106,10 @@
 # WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
 # only for migration purposes.
 #-Delasticsearch.json.allow_unquoted_field_names=true
+{% if jmx_remote_monitoring_enabled == true %}
+#-Dcom.sun.management.jmxremote.port={{ jmx_remote_monitoring_port }}
+#-Dcom.sun.management.jmxremote.authenticate={{ jmx_remote_monitoring_auth }}
+#-Dcom.sun.management.jmxremote.ssl={{ jmx_remote_monitoring_ssl }}
+##-Djava.rmi.server.hostname="127.0.0.1"
+-Dcom.sun.management.jmxremote
+{% endif %}


### PR DESCRIPTION
It would be nice to pass custom parameters to JVM used in Elasticsearch. For example:
es_jvm_custom_parameters:
  - "-Dcom.sun.management.jmxremote"
It enables us to collect metrics by prometheus jmx exporter via local JVM RMI interface.
