### PR TITLE
Add check_mode:no to x_pack_installed

### DIFF
--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -5,6 +5,7 @@
   register: x_pack_installed
   changed_when: False
   failed_when: "'ERROR' in x_pack_installed.stdout"
+  check_mode: no
   ignore_errors: yes
   environment:
     CONF_DIR: "{{ conf_dir }}"


### PR DESCRIPTION
Without this, the variable x_pack_installed doesn't get registered in check mode, and consequently playbook execution halts on the task "Remove x-pack plugin" which uses it in the when clause.