### PR TITLE
Add check_mode: no to prevent failing in --check mode

### DIFF
--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -3,6 +3,7 @@
 #Test if feature is installed
 - shell: "{{es_home}}/bin/plugin list | sed -n '1!p' | grep {{item}}"
   register: feature_installed
+  check_mode: no
   changed_when: False
   failed_when: "'ERROR' in feature_installed.stdout"
   ignore_errors: yes

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -9,6 +9,7 @@
   shell: >
     {{es_home}}/bin/plugin list | tail -n +2 | grep license
   register: license_installed
+  check_mode: no
   ignore_errors: yes
   failed_when: "'ERROR' in license_installed.stdout"
   changed_when: False


### PR DESCRIPTION
Adding check_mode:no to prevent ansible-playbook failing on missing dict_objects when running with --check.