### PR TITLE
Tracked files removed from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/vars/Debian.yml
 .kitchen/
 license*.json
 *.pyc

--- a/elasticsearch.iml
+++ b/elasticsearch.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="RUBY_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
There's a couple of files tracked by git but present in the .gitignore file. I'm not sure about elasticsearch.iml, but it was quite confusing when I pushed the role to a project and started to get complaints about "vars/Debian.yml not found" error.