### PR TITLE
Fix adding of plugins when es_plugins_reinstall is false

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -28,12 +28,19 @@
 - set_fact: plugins_to_remove="{{ installed_plugins.stdout_lines | difference(es_plugins | json_query('[*].plugin')) | default([]) }}"
   when: not es_plugins_reinstall
 
+#if es_plugins_reinstall is set to true we (re)install ALL plugins
+- set_fact: plugins_to_install="{{ es_plugins | json_query('[*].plugin') | default([]) }}"
+  when: es_plugins_reinstall
+
+#if the plugins listed are different than those requested, we install those not installed but listed in the config
+- set_fact: plugins_to_install="{{ es_plugins | json_query('[*].plugin') | difference(installed_plugins.stdout_lines) | default([]) }}"
+  when: not es_plugins_reinstall
+
 # This removes any currently installed plugins (to prevent errors when reinstalling)
 - name: Remove elasticsearch plugins
   command: "{{es_home}}/bin/elasticsearch-plugin remove {{item}} --silent"
   ignore_errors: yes
   with_items: "{{ plugins_to_remove | default([]) }}"
-  when: es_plugins_reinstall and plugins_to_remove | length > 0
   notify: restart elasticsearch
   register: plugin_removed
   environment:
@@ -45,8 +52,8 @@
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
-  with_items: "{{ es_plugins | default([]) }}"
-  when: not es_plugins is none and es_plugins_reinstall
+  with_items: "{{ es_plugins }}"
+  when: "{{ item.plugin in plugins_to_install }}"
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"


### PR DESCRIPTION
* Get (and use) list of plugins that need to be installed

Similar to getting/calculating the list of plugins that need to be removed, except that the `es_plugins` list also can contain additional data.

* Just remove all plugins of the remove list

After determining which plugins need to be removed, the `when` check is not required (anymore)