### PR TITLE
Change proxy specification for installation of x-pack plugin in ES 5

### DIFF
--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -27,8 +27,8 @@
 
 #Install plugin if not installed, or the es version has changed (so removed above), and its been requested
 - name: Install x-pack plugin
-  command: >
-    {{es_home}}/bin/elasticsearch-plugin install --silent --batch x-pack {% if es_proxy_host is defined and es_proxy_host != '' %} -Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} {% endif %}
+  shell: >
+    {% if es_proxy_host is defined and es_proxy_host != '' %}ES_JAVA_OPTS="-Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }}"{% endif %} {{ es_home }}/bin/elasticsearch-plugin install --silent --batch x-pack
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0


### PR DESCRIPTION
This pull request aims at solving #259 

According to https://www.elastic.co/guide/en/elasticsearch/plugins/5.2/_other_command_line_parameters.html
proxy is now specified using the ES_JAVA_OPT environment variable:

`ES_JAVA_OPTS="-Dhttp.proxyHost=host_name -Dhttp.proxyPort=port_number -Dhttps.proxyHost=host_name -Dhttps.proxyPort=https_port_number" 
`

Also replaced **command** module by **shell** module because **command** wasn't generating the command line correctly.

