### PR TITLE
fix the check for the openjdk

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -18,8 +18,9 @@
   apt: name={{ java }} state={{java_state}}
   when: ansible_os_family == 'Debian'
 
-- command: java -version 2>&1 | grep OpenJDK
+- shell: java -version 2>&1 | grep OpenJDK
   register: open_jdk
+  ignore_errors: yes
   changed_when: false
 
 #https://github.com/docker-library/openjdk/issues/19 - ensures tests pass due to java 8 broken certs


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3024538/25010711/81a29dc4-209d-11e7-8488-201d2f9d4e11.png)

replace the command with the shell module to check the open jdk. 