### PR TITLE
Moved up the x-pack directory logic to include role_mappings

### DIFF
--- a/tasks/xpack/security/elasticsearch-security-file.yml
+++ b/tasks/xpack/security/elasticsearch-security-file.yml
@@ -1,12 +1,6 @@
 ---
 - set_fact: manage_file_users=es_users is defined and es_users.file is defined
 
-#Ensure x-pack conf directory is created
-- name: Ensure x-pack conf directory exists (file)
-  file: path={{ conf_dir }}/x-pack state=directory owner={{ es_user }} group={{ es_group }}
-  changed_when: False
-  when: es_enable_xpack and '"security" in es_xpack_features'
-
 #List current users
 - name: List Users
   shell: cat {{conf_dir}}/x-pack/users | awk -F':' '{print $1}'

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -3,6 +3,14 @@
 
 #TODO: 1. Skip users with no password defined or error 2. Passwords | length > 6
 
+#Ensure x-pack conf directory is created if necessary
+- name: Ensure x-pack conf directory exists (file)
+  file: path={{ conf_dir }}/x-pack state=directory owner={{ es_user }} group={{ es_group }}
+  changed_when: False
+  when:
+    - es_enable_xpack and '"security" in es_xpack_features'
+    - (es_users is defined and es_users.file) or (es_roles is defined and es_roles.file is defined) or (es_role_mapping is defined)
+
 #-----------------------------FILE BASED REALM----------------------------------------
 
 - include: elasticsearch-security-file.yml


### PR DESCRIPTION
### Description

Fix for #290 

This just moves the x-pack directory creation up one level to be accessible by the `es_role_mapping` tasks which, until now, have incidentally relied on it.

### Testing

To test this, I've created a separate branch in my repo w/ a separate test because I didn't want to make the call to muddy up the pretty focused set of tests that currently exist.

My test is on the `role-mapping-xpack-dir-test` branch here: https://github.com/rusnyder/ansible-elasticsearch/tree/role-mapping-xpack-dir-test

To test this, you can demonstrate the failure case, patch this PR, then demonstrate success:

```
# Checkout the test branch (without the fix) and install dependencies
git clone https://github.com/rusnyder/ansible-elasticsearch elasticsearch
cd elasticsearch
git checkout role-mapping-xpack-dir-test
bundle install

# Run the tests and watch it fail
ES_XPACK_LICENSE_FILE=/path/to/license.json bundle exec kitchen test role-mapping-xpack-dir-centos-7

# Pull in the patch and watch the tests succeed!
git merge --no-commit role-mapping-xpack-dir
ES_XPACK_LICENSE_FILE=/path/to/license.json bundle exec kitchen test role-mapping-xpack-dir-centos-7
```