### PR TITLE
Ability to override path.repo property

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ es_config: {}
 es_pid_dir: "/var/run/elasticsearch"
 es_data_dirs: "/var/lib/elasticsearch"
 es_log_dir: "/var/log/elasticsearch"
+es_repo_dirs: {}
 es_max_open_files: 65536
 es_max_map_count: 262144
 es_allow_downgrades: false

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -47,3 +47,5 @@
 - set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
 - set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
 - set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
+- set_fact: repo_dirs={{ es_repo_dirs | append_to_list('/'+instance_suffix) }}
+  when: es_repo_dirs|length > 0

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -47,5 +47,3 @@
 - set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
 - set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
 - set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
-- set_fact: repo_dirs={{ es_repo_dirs | append_to_list('/'+instance_suffix) }}
-  when: es_repo_dirs|length > 0

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -20,6 +20,10 @@ path.data: {{ data_dirs | array_to_str }}
 
 path.logs: {{ log_dir }}
 
+{% if repo_dirs is defined and repo_dirs|length > 0 %}
+path.repo: ["{{ repo_dirs|join('", "') }}"]
+{% endif %}
+
 {% if not "security" in es_xpack_features %}
 xpack.security.enabled: false
 {% endif %}


### PR DESCRIPTION
Add property ```es_repo_dirs``` in defaults so that we can configure backups/restore repositories