### PR TITLE
fixed duplicate configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ A more complex example:
     es_templates: false
     es_version_lock: false
     es_heap_size: 1g
-    es_scripts: false
-    es_templates: false
-    es_version_lock: false
     es_start_service: false
     es_plugins_reinstall: false
     es_api_port:9201


### PR DESCRIPTION
Hello,
There appeared to be duplicate config issue in the samples
sample warnings...

[obalyuk@obalyuk-t450s elk]$ ansible-playbook -i hosts elastic-setup.yml 
 [WARNING]: While constructing a mapping from /home/obalyuk/Projects/misc-scripts/ansible/elk/elastic-setup.yml, line 23, column 5, found a duplicate dict key (es_scripts). Using last defined value only.

 [WARNING]: While constructing a mapping from /home/obalyuk/Projects/misc-scripts/ansible/elk/elastic-setup.yml, line 23, column 5, found a duplicate dict key (es_templates). Using last defined value only.

 [WARNING]: While constructing a mapping from /home/obalyuk/Projects/misc-scripts/ansible/elk/elastic-setup.yml, line 23, column 5, found a duplicate dict key (es_version_lock). Using last defined value only.