### PR TITLE
Fixes handler and file issues with ES templates

### DIFF
--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -6,29 +6,29 @@
 - name: Wait for elasticsearch to startup
   wait_for: host={{es_api_host}} port={{es_api_port}} delay=10
 
-- name: Get template files
-  find: paths="/etc/elasticsearch/templates" patterns="*.json"
-  register: templates
-
 - name: Install templates without auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item | filename}}"
     method: PUT
     status_code: 200
     body_format: json
-    body: "{{ lookup('file', item.path) }}"
+    body: "{{ lookup('file', item) }}"
   when: not es_enable_xpack or not es_xpack_features is defined or "security" not in es_xpack_features
-  with_items: "{{ templates.files }}"
+  with_fileglob:
+    - "{{ es_templates_fileglob | default('') }}"
+  run_once: True
 
 - name: Install templates with auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes
     body_format: json
-    body: "{{ lookup('file', item.path) }}"
+    body: "{{ lookup('file', item) }}"
   when: es_enable_xpack and es_xpack_features is defined and "security" in es_xpack_features
-  with_items: "{{ templates.files }}"
+  with_fileglob:
+    - "{{ es_templates_fileglob | default('') }}"
+  run_once: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,4 @@
-- name: reload systemd configuration
-  command: systemctl daemon-reload
-
-# Restart service and ensure it is enabled
-- name: restart elasticsearch
-  service: name={{instance_init_script | basename}} state=restarted enabled=yes
-  when: es_restart_on_change and es_start_service and ((plugin_installed is defined and plugin_installed.changed) or (config_updated is defined and config_updated.changed) or (xpack_state.changed) or (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed))
+---
 
 #Templates are a handler as they need to come after a restart e.g. suppose user removes security on a running node and doesn't
 #specify es_api_basic_auth_username and es_api_basic_auth_password.  The templates will subsequently not be removed if we don't wait for the node to restart.
@@ -13,3 +7,11 @@
 - name: load-templates
   include: ./handlers/elasticsearch-templates.yml
   when: es_templates
+
+- name: reload systemd configuration
+  command: systemctl daemon-reload
+
+# Restart service and ensure it is enabled
+- name: restart elasticsearch
+  service: name={{instance_init_script | basename}} state=restarted enabled=yes
+  when: es_restart_on_change and es_start_service and ((plugin_installed is defined and plugin_installed.changed) or (config_updated is defined and config_updated.changed) or (xpack_state.changed) or (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed))


### PR DESCRIPTION
Fixes an issue with handlers in Ansible 2.2.1+
[https://github.com/ansible/ansible/issues/20603](). Moves the
load-templates handler to the top of the file to get around this
issue.

Fixes an issue loading installed templates into ES. The use of
file lookup meant that the template files are checked on the
machine that initiated the Ansible play, this only works if Ansible
has been run locally, breaking for remote machines. Switched to
using the slurp module to grab file contents on the target machine.