### PR TITLE
Cleanup installation and make shared file system prefixes optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ es_use_shared_fs: false
 es_pid_dir: "/var/run/elasticsearch"
 es_data_dirs: ['/var/lib/elasticsearch']
 es_log_dir: "/var/log/elasticsearch"
+es_conf_dir: "/etc/elasticsearch"
 es_max_open_files: 65536
 es_max_threads: "{{ 2048 if ( es_version | version_compare('6.0.0', '<')) else 8192 }}"
 es_max_map_count: 262144

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ es_user: elasticsearch
 es_group: elasticsearch
 es_config: {}
 es_config_log4j2: log4j2.properties.j2
-es_use_shared_fs: false
+es_use_shared_fs: true
 #Need to provide default directories
 es_pid_dir: "/var/run/elasticsearch"
 es_data_dirs: ['/var/lib/elasticsearch']

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 es_major_version: "6.x"
 es_version: "6.1.3"
 es_instance_name: "{{ ansible_hostname }}"
-es_node_name: "{{ es_instance_name }}"
+es_node_name: "{{ inventory_hostname }}-{{ es_instance_name }}"
 es_version_lock: false
 es_use_repository: true
 es_templates_fileglob: "files/templates/*.json"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 es_major_version: "6.x"
 es_version: "6.1.3"
 es_instance_name: "{{ ansible_hostname }}"
+es_node_name: "{{ es_instance_name }}"
 es_version_lock: false
 es_use_repository: true
 es_templates_fileglob: "files/templates/*.json"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 es_major_version: "6.x"
 es_version: "6.1.3"
+es_instance_name: "{{ ansible_hostname }}"
 es_version_lock: false
 es_use_repository: true
 es_templates_fileglob: "files/templates/*.json"
@@ -18,9 +19,10 @@ es_user: elasticsearch
 es_group: elasticsearch
 es_config: {}
 es_config_log4j2: log4j2.properties.j2
+es_use_shared_fs: false
 #Need to provide default directories
 es_pid_dir: "/var/run/elasticsearch"
-es_data_dirs: "/var/lib/elasticsearch"
+es_data_dirs: ['/var/lib/elasticsearch']
 es_log_dir: "/var/log/elasticsearch"
 es_max_open_files: 65536
 es_max_threads: "{{ 2048 if ( es_version | version_compare('6.0.0', '<')) else 8192 }}"
@@ -28,17 +30,17 @@ es_max_map_count: 262144
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: ["alerting","monitoring","graph","ml","security"]
+es_xpack_file: "x-pack"
 #These are used for internal operations performed by ansible.
 #They do not affect the current configuration
 es_api_host: "localhost"
 es_api_port: 9200
 es_debian_startup_timeout: 10
 
-# Since ansible 2.2 the following variables need to be defined
-# to allow the role to be conditionally played with a when condition.
-pid_dir: ''
-log_dir: ''
-conf_dir: ''
-data_dirs: ''
+# These values get re-written if you set es_use_shared_fs to true
+pid_dir: "{{ es_pid_dir }}"
+log_dir: "{{ es_log_dir }}"
+conf_dir: "{{ es_conf_dir }}"
+data_dirs: "{{ es_data_dirs }}"
 # JVM custom parameters
 es_jvm_custom_parameters: ''

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -31,8 +31,7 @@
   become: yes
   apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present force={{force_install}} allow_unauthenticated={{ 'no' if es_apt_key else 'yes' }} cache_valid_time=86400
   when: es_use_repository
-  register: debian_elasticsearch_install_from_repo
-  notify: restart elasticsearch
+  register: es_install
 
 - name: Debian - Download elasticsearch from url
   get_url: url={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.deb{% endif %} dest=/tmp/elasticsearch-{{ es_version }}.deb validate_certs=no
@@ -42,5 +41,4 @@
   become: yes
   apt: deb=/tmp/elasticsearch-{{ es_version }}.deb
   when: not es_use_repository
-  register: elasticsearch_install_from_package
-  notify: restart elasticsearch
+  register: es_install

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -17,9 +17,8 @@
   become: yes
   yum: name=elasticsearch{% if es_version is defined and es_version != ""  %}-{{ es_version }}{% endif %} state=present update_cache=yes
   when: es_use_repository
-  register: redhat_elasticsearch_install_from_repo
-  notify: restart elasticsearch
-  until: '"failed" not in redhat_elasticsearch_install_from_repo'
+  register: es_install
+  until: '"failed" not in es_install'
   retries: 5
   delay: 10
 
@@ -27,5 +26,4 @@
   become: yes
   yum: name={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.noarch.rpm{% endif %} state=present
   when: not es_use_repository
-  register: elasticsearch_install_from_package
-  notify: restart elasticsearch
+  register: es_install

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -30,29 +30,6 @@
   template: src=elasticsearch.j2 dest={{instance_default_file}} mode=0644 force=yes
   notify: restart elasticsearch
 
-#Copy the instance specific init file
-- name: Copy Debian Init File for Instance
-  become: yes
-  template: src=init/debian/elasticsearch.j2 dest={{instance_init_script}} mode=0755 force=yes
-  when: ansible_os_family == 'Debian' and not use_system_d
-  notify: restart elasticsearch
-
-#Copy the instance specific init file
-- name: Copy Redhat Init File for Instance
-  become: yes
-  template: src=init/redhat/elasticsearch.j2 dest={{instance_init_script}} mode=0755 force=yes
-  when: ansible_os_family == 'RedHat' and not use_system_d
-  notify: restart elasticsearch
-
-#Copy the systemd specific file if systemd is installed
-- name: Copy Systemd File for Instance
-  become: yes
-  template: src=systemd/elasticsearch.j2 dest={{instance_sysd_script}} mode=0644 force=yes
-  when: use_system_d
-  notify:
-  - reload systemd configuration
-  - restart elasticsearch
-
 #Copy the logging.yml
 - name: Copy log4j2.properties File for Instance
   become: yes
@@ -64,38 +41,5 @@
   template: src=jvm.options.j2 dest={{conf_dir}}/jvm.options owner={{ es_user }} group={{ es_group }} mode=0644 force=yes
   notify: restart elasticsearch
 
-#Clean up un-wanted package scripts to avoid confusion
-
-- name: Delete Default Init
-  become: yes
-  file: dest=/etc/init.d/elasticsearch state=absent
-
-- name: Delete Default Environment File
-  become: yes
-  file: dest=/etc/default/elasticsearch state=absent
-  when: ansible_os_family == 'Debian'
-
-- name: Delete Default Environment File
-  become: yes
-  file: dest=/etc/sysconfig/elasticsearch state=absent
-  when: ansible_os_family == 'RedHat'
-
-- name: Delete Default Sysconfig File
-  become: yes
-  file: dest="{{ sysd_script }}" state=absent
-
-- name: Delete Default Configuration File
-  become: yes
-  file: dest=/etc/elasticsearch/elasticsearch.yml state=absent
-
-- name: Delete Default Logging File
-  become: yes
-  file: dest=/etc/elasticsearch/logging.yml state=absent
-
-- name: Delete Default Logging File
-  become: yes
-  file: dest=/etc/elasticsearch/log4j2.properties state=absent
-
-- name: Delete Default JVM Options File
-  become: yes
-  file: dest=/etc/elasticsearch/jvm.options state=absent
+- name: Include tasks specific to installed service manager
+  include: elasticsearch-{{ ansible_service_mgr }}.yml

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -1,8 +1,5 @@
+---
 # Check for mandatory parameters
-
-- fail: msg="es_instance_name must be specified and cannot be blank"
-  when: es_instance_name is not defined or es_instance_name == ''
-
 - fail: msg="es_proxy_port must be specified and cannot be blank when es_proxy_host is defined"
   when: (es_proxy_port is not defined or es_proxy_port == '') and (es_proxy_host is defined and es_proxy_host != '')
 
@@ -37,20 +34,6 @@
 
 #TODO - if transport.host is not local maybe error on boostrap checks
 
-
-#Use systemd for the following distributions:
-#Ubuntu 15 and up
-#Debian 8 and up
-#Centos 7 and up
-#Relies on elasticsearch distribution installing a serviced script to determine whether one should be copied.
-
-- set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>=')) }}
-
-- set_fact: instance_sysd_script={{sysd_script | dirname }}/{{es_instance_name}}_{{sysd_script | basename}}
-  when: use_system_d
-#For directories we also use the {{inventory_hostname}}-{{ es_instance_name }} - this helps if we have a shared SAN.
-
-- set_fact: instance_suffix={{inventory_hostname}}-{{ es_instance_name }}
-- set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
-- set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
-- set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
+- set_fact: instance_default_file={{ default_file }}
+- set_fact: instance_init_script={{ init_script }}
+- set_fact: instance_sysd_script={{ sysd_script }}

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -30,6 +30,7 @@
 - set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name}}_{{default_file | basename}}
 - set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name}}_{{init_script | basename}}
 - set_fact: conf_dir={{ es_conf_dir }}/{{es_instance_name}}
+  when: es_use_shared_fs
 - set_fact: m_lock_enabled={{ es_config['bootstrap.memory_lock'] is defined and es_config['bootstrap.memory_lock'] == True }}
 
 #TODO - if transport.host is not local maybe error on boostrap checks

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -27,9 +27,9 @@
      msg: "ERROR: INVALID CONFIG - YOU CANNOT CHANGE RESERVED USERS THROUGH THE FILE REALM. THE FOLLOWING CANNOT BE CHANGED: {{file_reserved_users}}. USE THE NATIVE REALM."
   when: file_reserved_users | default([]) | length > 0
 
-- set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name}}_{{default_file | basename}}
-- set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name}}_{{init_script | basename}}
-- set_fact: conf_dir={{ es_conf_dir }}/{{es_instance_name}}
+- set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}
+- set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name + '_' if es_use_shared_fs else ''}}{{init_script | basename}}
+- set_fact: conf_dir={{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
   when: es_use_shared_fs
 - set_fact: m_lock_enabled={{ es_config['bootstrap.memory_lock'] is defined and es_config['bootstrap.memory_lock'] == True }}
 

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -27,10 +27,6 @@
      msg: "ERROR: INVALID CONFIG - YOU CANNOT CHANGE RESERVED USERS THROUGH THE FILE REALM. THE FOLLOWING CANNOT BE CHANGED: {{file_reserved_users}}. USE THE NATIVE REALM."
   when: file_reserved_users | default([]) | length > 0
 
-- set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}
-- set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name + '_' if es_use_shared_fs else ''}}{{init_script | basename}}
-- set_fact: conf_dir={{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
-  when: es_use_shared_fs
 - set_fact: m_lock_enabled={{ es_config['bootstrap.memory_lock'] is defined and es_config['bootstrap.memory_lock'] == True }}
 
 #TODO - if transport.host is not local maybe error on boostrap checks

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -2,8 +2,7 @@
 
 # es_plugins_reinstall will be set to true if elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed
 # i.e. we have changed ES version(or we have clean installation of ES), or if no plugins listed. Otherwise it is false and requires explicitly setting.
-- set_fact: es_plugins_reinstall=true
-  when: (((debian_elasticsearch_install_from_repo is defined and debian_elasticsearch_install_from_repo.changed) or (redhat_elasticsearch_install_from_repo is defined and redhat_elasticsearch_install_from_repo.changed)) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) or es_plugins is not defined or es_plugins is none
+- set_fact: es_plugins_reinstall={{ es_install.changed }}
 
 - set_fact: list_command=""
 #If we are reinstalling all plugins, e.g. to a version change, we need to remove all plugins (inc. x-pack) to install any plugins. Otherwise we don't consider x-pack so the role stays idempotent.
@@ -52,8 +51,12 @@
     ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
+<<<<<<< HEAD
   become: yes
   command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent"
+=======
+  command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent "
+>>>>>>> Simplify xpack and add support for es_use_shared_fs: false
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
@@ -64,7 +67,11 @@
     CONF_DIR: "{{ conf_dir }}"
     ES_PATH_CONF: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
+<<<<<<< HEAD
     ES_JAVA_OPTS: "{% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -Dhttp.proxyHost={{ item.proxy_host }} -Dhttp.proxyPort={{ item.proxy_port }} -Dhttps.proxyHost={{ item.proxy_host }} -Dhttps.proxyPort={{ item.proxy_port }}  {% elif es_proxy_host is defined and es_proxy_host != '' %} -Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }} {% endif %}"
+=======
+    ES_JAVA_OPTS: "{% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %}"
+>>>>>>> Simplify xpack and add support for es_use_shared_fs: false
   until: plugin_installed.rc == 0
   retries: 5
   delay: 5

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -51,12 +51,8 @@
     ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
-<<<<<<< HEAD
   become: yes
   command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent"
-=======
-  command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent "
->>>>>>> Simplify xpack and add support for es_use_shared_fs: false
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
@@ -67,11 +63,7 @@
     CONF_DIR: "{{ conf_dir }}"
     ES_PATH_CONF: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
-<<<<<<< HEAD
-    ES_JAVA_OPTS: "{% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -Dhttp.proxyHost={{ item.proxy_host }} -Dhttp.proxyPort={{ item.proxy_port }} -Dhttps.proxyHost={{ item.proxy_host }} -Dhttps.proxyPort={{ item.proxy_port }}  {% elif es_proxy_host is defined and es_proxy_host != '' %} -Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }} {% endif %}"
-=======
     ES_JAVA_OPTS: "{% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %}"
->>>>>>> Simplify xpack and add support for es_use_shared_fs: false
   until: plugin_installed.rc == 0
   retries: 5
   delay: 5

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -1,6 +1,6 @@
 ---
 
-- set_fact: es_script_dir={{ es_conf_dir }}/{{es_instance_name}}
+- set_fact: es_script_dir={{ es_conf_dir }}{{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
   tags:
       - always
 

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -1,6 +1,6 @@
 ---
 
-- set_fact: es_script_dir={{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
+- set_fact: es_script_dir={{ es_conf_dir }}/scripts{{'/' + es_instance_name if es_use_shared_fs else ''}}
   tags:
       - always
 

--- a/tasks/elasticsearch-scripts.yml
+++ b/tasks/elasticsearch-scripts.yml
@@ -1,6 +1,6 @@
 ---
 
-- set_fact: es_script_dir={{ es_conf_dir }}{{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
+- set_fact: es_script_dir={{ es_conf_dir }}{{'/' + es_instance_name if es_use_shared_fs else ''}}
   tags:
       - always
 

--- a/tasks/elasticsearch-sharedfs.yml
+++ b/tasks/elasticsearch-sharedfs.yml
@@ -1,0 +1,38 @@
+---
+# Add instance name to paths
+- set_fact: instance_default_file={{default_file | dirname}}/{{es_instance_name}}_{{default_file | basename}}
+- set_fact: instance_init_script={{init_script | dirname }}/{{es_instance_name}}_{{init_script | basename}}
+- set_fact: conf_dir={{ es_conf_dir }}/{{es_instance_name}}
+- set_fact: instance_sysd_script={{sysd_script | dirname }}/{{es_instance_name}}_{{sysd_script | basename}}
+- set_fact: instance_suffix={{inventory_hostname}}-{{ es_instance_name }}
+- set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
+- set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
+- set_fact: data_dirs={{ es_data_dirs | append_to_list('/'+instance_suffix) }}
+
+#Clean up un-wanted package scripts to avoid confusion
+
+- name: Delete Default Init
+  file: dest=/etc/init.d/elasticsearch state=absent
+
+- name: Delete Default Environment File
+  file: dest=/etc/default/elasticsearch state=absent
+  when: ansible_os_family == 'Debian'
+
+- name: Delete Default Environment File
+  file: dest=/etc/sysconfig/elasticsearch state=absent
+  when: ansible_os_family == 'RedHat'
+
+- name: Delete Default Sysconfig File
+  file: dest="{{ sysd_script }}" state=absent
+
+- name: Delete Default Configuration File
+  file: dest=/etc/elasticsearch/elasticsearch.yml state=absent
+
+- name: Delete Default Logging File
+  file: dest=/etc/elasticsearch/logging.yml state=absent
+
+- name: Delete Default Logging File
+  file: dest=/etc/elasticsearch/log4j2.properties state=absent
+
+- name: Delete Default JVM Options File
+  file: dest=/etc/elasticsearch/jvm.options state=absent

--- a/tasks/elasticsearch-systemd.yml
+++ b/tasks/elasticsearch-systemd.yml
@@ -1,0 +1,7 @@
+---
+#Copy the systemd specific file
+- name: Copy Systemd File for Instance
+  template: src=systemd/elasticsearch.j2 dest={{instance_sysd_script}} mode=0644 force=yes
+  notify:
+  - reload systemd configuration
+  - restart elasticsearch

--- a/tasks/elasticsearch-upstart.yml
+++ b/tasks/elasticsearch-upstart.yml
@@ -1,0 +1,12 @@
+---
+#Copy the instance specific init file
+- name: Copy Debian Init File for Instance
+  template: src=init/debian/elasticsearch.j2 dest={{instance_init_script}} mode=0755 force=yes
+  when: ansible_os_family == 'Debian'
+  notify: restart elasticsearch
+
+#Copy the instance specific init file
+- name: Copy Redhat Init File for Instance
+  template: src=init/redhat/elasticsearch.j2 dest={{instance_init_script}} mode=0755 force=yes
+  when: ansible_os_family == 'RedHat'
+  notify: restart elasticsearch

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -5,9 +5,4 @@
   include: elasticsearch-optional-user.yml
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-Debian.yml
-  when: ansible_os_family == 'Debian'
-
-- name: Include specific Elasticsearch
-  include: elasticsearch-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  include: elasticsearch-{{ ansible_os_family }}.yml

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -11,7 +11,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Get the installed java path
-  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0"
+  shell: "/usr/sbin/update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0"
   register: java_full_path
   failed_when: False
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,9 @@
   tags:
       - install
 
+- include: elasticsearch-sharedfs.yml
+  when: es_use_shared_fs
+
 - include: elasticsearch-config.yml
   tags:
       - config

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -21,7 +21,7 @@
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0
-  when: x_pack_installed.rc == 0 and (not es_enable_xpack or es_version_changed)
+  when: x_pack_installed.rc == 0 and (not es_enable_xpack or es_install.changed)
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"
@@ -30,38 +30,18 @@
 
 
 #Install plugin if not installed, or the es version has changed (so removed above), and its been requested
-- name: Download x-pack from url
-  get_url: url={{ es_xpack_custom_url }} dest=/tmp/x-pack-{{ es_version }}.zip
-  when: (x_pack_installed.rc == 1 or es_version_changed) and (es_enable_xpack and es_xpack_custom_url is defined)
-
-- name: Install x-pack plugin from local
-  become: yes
-  command: >
-    {{es_home}}/bin/elasticsearch-plugin install --silent --batch file:///tmp/x-pack-{{ es_version }}.zip
-  register: xpack_state
-  changed_when: xpack_state.rc == 0
-  when: (x_pack_installed.rc == 1 or es_version_changed) and (es_enable_xpack and es_xpack_custom_url is defined)
-  notify: restart elasticsearch
-  environment:
-    CONF_DIR: "{{ conf_dir }}"
-    ES_PATH_CONF: "{{ conf_dir }}"
-    ES_INCLUDE: "{{ instance_default_file }}"
-
-- name: Delete x-pack zip file
-  file: dest=/tmp/x-pack-{{ es_version }}.zip state=absent
-  when: es_xpack_custom_url is defined
-
-- name: Install x-pack plugin from elastic.co
-  become: yes
-  command: >
-    {{es_home}}/bin/elasticsearch-plugin install --silent --batch x-pack
+- name: Install x-pack plugin
+  shell: >
+    {% if es_proxy_host is defined and es_proxy_host != '' %}
+    ES_JAVA_OPTS="-DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }}"
+    {% endif %}
+    {{es_home}}/bin/elasticsearch-plugin install --silent --batch {{ es_xpack_file }}
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0
-  when: (x_pack_installed.rc == 1 or es_version_changed) and (es_enable_xpack and es_xpack_custom_url is not defined)
+  when: (x_pack_installed.rc == 1 or es_install.changed) and es_enable_xpack
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_PATH_CONF: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
-    ES_JAVA_OPTS: "{% if es_proxy_host is defined and es_proxy_host != '' %}-Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }}{% endif %}"

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -1,7 +1,4 @@
 ---
-
-- set_fact: es_version_changed={{ ((elasticsearch_install_from_package is defined and (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed)) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) }}
-
 - include: elasticsearch-xpack-install.yml
 
 #Security configuration

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -8,7 +8,7 @@ cluster.name: elasticsearch
 {% endif %}
 
 {% if es_config['node.name'] is not defined %}
-node.name: {{inventory_hostname}}{{'-' + es_instance_name if es_use_shared_fs else ''}}
+node.name: {{ es_node_name }}
 {% endif %}
 
 #################################### Paths ####################################

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -8,7 +8,7 @@ cluster.name: elasticsearch
 {% endif %}
 
 {% if es_config['node.name'] is not defined %}
-node.name: {{inventory_hostname}}-{{es_instance_name}}
+node.name: {{inventory_hostname}}{{' - ' + es_instance_name if es_use_shared_fs else ''}}
 {% endif %}
 
 #################################### Paths ####################################

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -13,14 +13,10 @@
 ### END INIT INFO
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
-NAME={{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}
-{% if es_config['node.name'] is defined %}
-DESC="Elasticsearch Server{{' - ' + es_config['node.name'] if es_use_shared_fs else ''}}"
-{% else %}
-DESC="Elasticsearch Server{{' - ' + es_instance_name if es_use_shared_fs else ''}}"
-{% endif %}
+NAME={{instance_default_file | basename}}
+DESC="Elasticsearch"
 
-DEFAULT=/etc/default/$NAME
+DEFAULT={{ instance_default_file }}
 
 if [ `id -u` -ne 0 ]; then
 	echo "You need root privileges to run this script"

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -13,11 +13,11 @@
 ### END INIT INFO
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
-NAME={{es_instance_name}}_{{default_file | basename}}
+NAME={{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}
 {% if es_config['node.name'] is defined %}
-DESC="Elasticsearch Server - {{es_config['node.name']}}"
+DESC="Elasticsearch Server{{' - ' + es_config['node.name'] if es_use_shared_fs else ''}}"
 {% else %}
-DESC="Elasticsearch Server - {{es_instance_name}}"
+DESC="Elasticsearch Server{{' - ' + es_instance_name if es_use_shared_fs else ''}}"
 {% endif %}
 
 DEFAULT=/etc/default/$NAME

--- a/templates/init/redhat/elasticsearch.j2
+++ b/templates/init/redhat/elasticsearch.j2
@@ -67,7 +67,7 @@ if [ ! -z "$CONF_FILE" ]; then
 fi
 
 exec="$ES_HOME/bin/elasticsearch"
-prog="{{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}"
+prog="{{instance_default_file | basename}}"
 pidfile="$PID_DIR/${prog}.pid"
 
 export ES_JAVA_OPTS

--- a/templates/init/redhat/elasticsearch.j2
+++ b/templates/init/redhat/elasticsearch.j2
@@ -67,7 +67,7 @@ if [ ! -z "$CONF_FILE" ]; then
 fi
 
 exec="$ES_HOME/bin/elasticsearch"
-prog="{{es_instance_name}}_{{default_file | basename}}"
+prog="{{es_instance_name + '_' if es_use_shared_fs else ''}}{{default_file | basename}}"
 pidfile="$PID_DIR/${prog}.pid"
 
 export ES_JAVA_OPTS

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Elasticsearch{{'-' + es_instance_name if es_use_shared_fs else ''}}
+Description=Elasticsearch
 Documentation=http://www.elastic.co
 Wants=network-online.target
 After=network-online.target

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Elasticsearch-{{es_instance_name}}
+Description=Elasticsearch{{' - ' + es_instance_name if es_use_shared_fs else ''}}
 Documentation=http://www.elastic.co
 Wants=network-online.target
 After=network-online.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 es_package_url: "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch"
-es_conf_dir: "/etc/elasticsearch"
 sysd_script: "/usr/lib/systemd/system/elasticsearch.service"
 init_script: "/etc/init.d/elasticsearch"
 #add supported features here


### PR DESCRIPTION
This is a lot of small changes and I wanted to submit them as separate pull requests for easier review, but a lot of them ended up being dependent on each other. I believe ee73f18 can be pulled out and moved to a separate PR if necessary, but I left it in there because I couldn't get my playbook to run without it.

The primary goal of this PR is to make the shared filesystem stuff optional, because I got tired of having to prefix the instance name to the service name when performing maintenance. I think the prefix is useful and necessary when operating in specific environments, but it adds unnecessary complexity for a lot of use cases.