### PR TITLE
Allow HTTPS API access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ A more complex example:
 
 #### Important Note
 
-**The role uses es_api_host and es_api_port to communicate with the node for actions only achievable via http e.g. to install templates and to check the NODE IS ACTIVE.  These default to "localhost" and 9200 respectively.  
+**The role uses es_api_scheme, es_api_host, and es_api_port to communicate with the node for actions only achievable via http e.g. to install templates and to check the NODE IS ACTIVE.  These default to "http", "localhost", and 9200 respectively.  
 If the node is deployed to bind on either a different host or port, these must be changed.**
 
 ### Multi Node Server Installations

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,8 +27,10 @@ es_enable_xpack: false
 es_xpack_features: ["alerting","monitoring","graph","security"]
 #These are used for internal operations performed by ansible.
 #They do not effect the current configuration
+es_api_scheme: "http"
 es_api_host: "localhost"
 es_api_port: 9200
+es_api_uri: "{{es_api_scheme}}://{{es_api_host}}:{{es_api_port}}"
 
 # Since ansible 2.2 the following variables need to be defined
 # to allow the role to be conditionally played with a when condition.

--- a/handlers/elasticsearch-templates.yml
+++ b/handlers/elasticsearch-templates.yml
@@ -12,7 +12,7 @@
 
 - name: Install templates without auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "{{es_api_uri}}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     body_format: json
@@ -22,7 +22,7 @@
 
 - name: Install templates with auth
   uri:
-    url: "http://{{es_api_host}}:{{es_api_port}}/_template/{{item.path | filename}}"
+    url: "{{es_api_uri}}/_template/{{item.path | filename}}"
     method: PUT
     status_code: 200
     user: "{{es_api_basic_auth_username}}"

--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -19,7 +19,7 @@
 #List current users
 - name: List Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user
+    url: "{{es_api_uri}}/_xpack/security/user"
     method: GET
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
@@ -39,7 +39,7 @@
 #Delete all non required users
 - name: Delete Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}
+    url: "{{es_api_uri}}/_xpack/security/user/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -54,7 +54,7 @@
 #Overwrite all other users
 - name: Update Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item.key}}
+    url: "{{es_api_uri}}/_xpack/security/user/{{item.key}}"
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"
@@ -69,7 +69,7 @@
 #List current roles not. inc those reserved
 - name: List Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role
+    url: "{{es_api_uri}}/_xpack/security/role"
     method: GET
     body_format: json
     user: "{{es_api_basic_auth_username}}"
@@ -90,7 +90,7 @@
 #Delete all non required roles
 - name: Delete Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}
+    url: "{{es_api_uri}}/_xpack/security/role/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -106,7 +106,7 @@
 #Update other roles
 - name: Update Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item.key}}
+    url: "{{es_api_uri}}/_xpack/security/role/{{item.key}}"
     method: POST
     body_format: json
     body: "{{item.value | to_json}}"

--- a/tasks/xpack/security/elasticsearch-xpack-activation.yml
+++ b/tasks/xpack/security/elasticsearch-xpack-activation.yml
@@ -3,7 +3,7 @@
 - name: Activate ES license (without security authentication)
   uri:
     method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    url: "{{es_api_uri}}/_license?acknowledge=true"
     body_format: json
     body: "{{ es_xpack_license }}"
     return_content: yes
@@ -18,7 +18,7 @@
 - name: Activate ES license (with security authentication)
   uri:
     method: PUT
-    url: "http://{{es_api_host}}:{{es_api_port}}/_license?acknowledge=true"
+    url: "{{es_api_uri}}/_license?acknowledge=true"
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
     body_format: json


### PR DESCRIPTION
"http" was hardcoded as the scheme whereever the Ansible URI module made
use of the `es_api_host` and `es_api_port` variables.

The `es_api_scheme` and `es_api_uri` variables were added to allow for
https access to the cluster.