### PR TITLE
allow max threads to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Additional parameters to es_config allow the customization of the Java and Elast
 * ```update_java``` Updates Java to the latest version. (true or false (default))
 * ```es_max_map_count``` maximum number of VMA (Virtual Memory Areas) a process can own. Defaults to 262144.
 * ```es_max_open_files``` the maximum file descriptor number that can be opened by this process. Defaults to 65536.
+* ```es_max_threads``` the maximum number of threads the process can start. Defaults to 2048 (the minimum required by elasticsearch).
 
 Earlier examples illustrate the installation of plugins using `es_plugins`.  For officially supported plugins no version or source delimiter is required. The plugin script will determine the appropriate plugin version based on the target Elasticsearch version.  For community based plugins include the full url.  This approach should NOT be used for the X-Pack plugin.  See X-Pack below for details here.
  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ es_pid_dir: "/var/run/elasticsearch"
 es_data_dirs: "/var/lib/elasticsearch"
 es_log_dir: "/var/log/elasticsearch"
 es_max_open_files: 65536
+es_max_threads: 2048
 es_max_map_count: 262144
 es_allow_downgrades: false
 es_enable_xpack: false

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -48,6 +48,10 @@ LimitNOFILE={{es_max_open_files}}
 LimitMEMLOCK=infinity
 {% endif %}
 
+# Specifies the maximum number of threads that can be started.  Elasticsearch requires a
+# minimum of 2048.
+LimitNPROC={{ es_max_threads }}
+
 # Disable timeout logic and wait until process is stopped
 TimeoutStopSec=0
 


### PR DESCRIPTION
Im not sure if this is entirely correct or cross platform.  The problem I was facing was that systemd does not respect the limits specified in /etc/security/limits.conf.  Instead they have to be specified directly in the unit file.