### PR TITLE
Ensure elasticsearch is always started and fix yum proxy logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,9 @@
 
 - meta: flush_handlers
 
+- name: Make sure elasticsearch is started
+  service: name={{instance_init_script | basename}} state=started enabled=yes
+
 - name: Wait for elasticsearch to startup
   wait_for: host={{es_api_host}} port={{es_api_port}} delay=5 connect_timeout=1
 

--- a/templates/elasticsearch.repo
+++ b/templates/elasticsearch.repo
@@ -4,7 +4,6 @@ baseurl=https://artifacts.elastic.co/packages/{{ es_major_version }}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1
-{% if es_proxy_host is defined and es_proxy_port is defined %}
+{% if es_proxy_host is defined and es_proxy_host != '' and es_proxy_port is defined %}
 proxy=http://{{ es_proxy_host }}:{{es_proxy_port}}
 {% endif %}
-


### PR DESCRIPTION
Ensure that elasticsearch is started/running even if non of the handlers
are called. Previously, if the host was provisioned correctly, but
elasticsearch was not running the role would not attempt to start it.
This can happen if elasticsearch was killed, or if the previous ansible
run failed prior to running the handlers.

Previously if the proxy host was defined but empty, an invalid proxy was
config was added and the install would fail. This is likely to occur
for instances where you conditionally set the proxy.