### PR TITLE
Update default elasticsearch version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 es_major_version: "5.x"
-es_version: "5.2.2"
+es_version: "5.4.2"
 es_version_lock: false
 es_use_repository: true
 es_apt_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"


### PR DESCRIPTION
This lead to some confusion. I was debugging why Cross Cluster Search options were not working, only to realize that the Ansible role points to an old version of elasticsearch by default.