### PR TITLE
Enable certificate deployment as part of X-Pack Security set-up

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,10 @@ es_max_map_count: 262144
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: ["alerting","monitoring","graph","security"]
+es_xpack_ssl_key_src: ''
+es_xpack_ssl_certificate_src: ''
+es_xpack_ssl_certificate_authorities_src: ''
+es_xpack_certificates_on_host: 'no'
 #These are used for internal operations performed by ansible.
 #They do not effect the current configuration
 es_api_host: "localhost"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,11 +30,6 @@ es_xpack_ssl_certificate_src: ''
 es_xpack_ssl_certificate_authorities_src: ''
 es_xpack_certificates_on_host: 'no'
 
-es_xpack_monitoring_datastore_host: ""
-es_xpack_monitoring_metrics_datastore_port: ""
-es_xpack_monitoring_metrics_datastore_protocol: ""
-es_xpack_monitoring_metrics_datastore_user: ""
-es_xpack_monitoring_metrics_datastore_password: ""
 #These are used for internal operations performed by ansible.
 #They do not effect the current configuration
 es_api_host: "localhost"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,10 @@ es_max_map_count: 262144
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: ["alerting","monitoring","graph","security"]
+
+# These are used for specifying the location of certificat and
+# key files to be deployed when setting up X-Pack security.
+# Leave as empty strings in order to skip installation.
 es_xpack_ssl_key_src: ''
 es_xpack_ssl_certificate_src: ''
 es_xpack_ssl_certificate_authorities_src: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,12 @@ es_xpack_ssl_key_src: ''
 es_xpack_ssl_certificate_src: ''
 es_xpack_ssl_certificate_authorities_src: ''
 es_xpack_certificates_on_host: 'no'
+
+es_xpack_monitoring_datastore_host: ""
+es_xpack_monitoring_metrics_datastore_port: ""
+es_xpack_monitoring_metrics_datastore_protocol: ""
+es_xpack_monitoring_metrics_datastore_user: ""
+es_xpack_monitoring_metrics_datastore_password: ""
 #These are used for internal operations performed by ansible.
 #They do not effect the current configuration
 es_api_host: "localhost"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,10 @@
   tags:
       - install
 
+  # Certificates need to be created and deployed before config can be updated
+- include: xpack/security/elasticsearch-security-certificates.yml
+  when: '"security" in es_xpack_features'
+
 - include: elasticsearch-config.yml
   tags:
       - config

--- a/tasks/xpack/security/elasticsearch-security-certificates.yml
+++ b/tasks/xpack/security/elasticsearch-security-certificates.yml
@@ -1,0 +1,33 @@
+---
+- set_fact: es_xpack_enable_tls=true
+  when: ((es_xpack_ssl_key_src != '') and (es_xpack_ssl_certificate_src != '') and (es_xpack_ssl_certificate_authorities_src != ''))
+
+- set_fact: es_xpack_enable_tls=false
+  when: ((es_xpack_ssl_key_src == '') and (es_xpack_ssl_certificate_src == '') and (es_xpack_ssl_certificate_authorities_src == ''))
+
+- fail:
+    msg: "es_xpack_ssl_key_src, es_xpack_ssl_certificate_src and es_xpack_ssl_certificate_authorities_src must all be provided to enable TLS"
+  when: es_xpack_enable_tls is not defined
+
+- file: path={{ conf_dir }}/security/certs state=directory owner={{ es_user }} group={{ es_group }}
+  changed_when: False
+  when: es_enable_xpack and '"security" in es_xpack_features' and es_xpack_enable_tls
+
+- set_fact: 
+    es_xpack_ssl_key_path: "{{ conf_dir }}/security/certs/{{ es_xpack_ssl_key_src | basename }}"
+    es_xpack_ssl_certificate_path: "{{ conf_dir }}/security/certs/{{ es_xpack_ssl_certificate_src | basename }}"
+    es_xpack_ssl_certificate_authorities_path: "{{ conf_dir }}/security/certs/{{ es_xpack_ssl_certificate_authorities_src | basename }}"
+  when: es_xpack_enable_tls
+
+- copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ es_user }}"
+    group: "{{ es_group }}"
+    mode: 0400
+    remote_src: "{{ es_xpack_certificates_on_host }}"
+  with_items:
+    - { src: "{{ es_xpack_ssl_key_src }}", dest: "{{ es_xpack_ssl_key_path }}" }
+    - { src: "{{ es_xpack_ssl_certificate_src }}", dest: "{{ es_xpack_ssl_certificate_path }}" }
+    - { src: "{{ es_xpack_ssl_certificate_authorities_src }}", dest: "{{ es_xpack_ssl_certificate_authorities_path }}" }
+  when: es_xpack_enable_tls

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -28,3 +28,6 @@
   file: path={{ conf_dir }}/security state=directory owner={{ es_user }} group={{ es_group }}
   changed_when: False
   when: es_enable_xpack and '"security" in es_xpack_features'
+
+- include: elasticsearch-security-certificates.yml
+  when: (es_enable_xpack and '"security" in es_xpack_features')

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -36,15 +36,6 @@ xpack.security.http.ssl.enabled: true
 xpack.monitoring.enabled: false
 {% endif %}
 
-{% if ("monitoring" in es_xpack_features) and (es_xpack_monitoring_metrics_datastore_host != '') %}
-xpack.monitoring.exporters.id1.type: {{ es_xpack_monitoring_metrics_datastore_protocol }}
-xpack.monitoring.exporters.id1.host: ['{{ es_xpack_monitoring_metrics_datastore_protocol }]://{{ es_xpack_monitoring_metrics_datastore_host }}:{{ es_xpack_monitoring_metrics_datastore_port }}'] 
-{% endif %}
-{% if ("monitoring" in es_xpack_features) and (es_xpack_monitoring_metrics_datastore_user != '') %}
-xpack.monitoring.exporters.id1.auth.username: {{ es_xpack_monitoring_metrics_datastore_user }}
-xpack.monitoring.exporters.id1.auth.password: {{ es_xpack_monitoring_metrics_datastore_password }}
-{% endif %}
-
 {% if not "alerting" in es_xpack_features %}
 xpack.watcher.enabled: false
 {% endif %}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -24,6 +24,14 @@ path.logs: {{ log_dir }}
 xpack.security.enabled: false
 {% endif %}
 
+{% if ("security" in es_xpack_features) and (es_xpack_ssl_key_src != '') %}
+xpack.ssl.key: {{ es_xpack_ssl_key_path }}
+xpack.ssl.certificate: {{ es_xpack_ssl_certificate_path }}
+xpack.ssl.certificate_authorities: [ {{ es_xpack_ssl_certificate_authorities_path }} ]
+xpack.security.transport.ssl.enabled: true
+xpack.security.http.ssl.enabled: true
+{% endif %}
+
 {% if not "monitoring" in es_xpack_features %}
 xpack.monitoring.enabled: false
 {% endif %}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -36,6 +36,15 @@ xpack.security.http.ssl.enabled: true
 xpack.monitoring.enabled: false
 {% endif %}
 
+{% if ("monitoring" in es_xpack_features) and (es_xpack_monitoring_metrics_datastore_host != '') %}
+xpack.monitoring.exporters.id1.type: {{ es_xpack_monitoring_metrics_datastore_protocol }}
+xpack.monitoring.exporters.id1.host: ['{{ es_xpack_monitoring_metrics_datastore_protocol }]://{{ es_xpack_monitoring_metrics_datastore_host }}:{{ es_xpack_monitoring_metrics_datastore_port }}'] 
+{% endif %}
+{% if ("monitoring" in es_xpack_features) and (es_xpack_monitoring_metrics_datastore_user != '') %}
+xpack.monitoring.exporters.id1.auth.username: {{ es_xpack_monitoring_metrics_datastore_user }}
+xpack.monitoring.exporters.id1.auth.password: {{ es_xpack_monitoring_metrics_datastore_password }}
+{% endif %}
+
 {% if not "alerting" in es_xpack_features %}
 xpack.watcher.enabled: false
 {% endif %}


### PR DESCRIPTION
The playbook does not currently seem to support deploying and configuring certificates as part of setting up X-Pack security. This PR adds support for uploading and deploying certificates as part of the installation. I am new to Ansible, so any feedback and suggestions around how to improve this will be much appreciated.