### PR TITLE
Add custom parameters for controlling number and size of main cluster…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,8 @@ conf_dir: ''
 data_dirs: ''
 # JVM custom parameters
 es_jvm_custom_parameters: ''
+
+#Log4j2 parameters
+es_log4j2_logfile_size_control: false
+#es_log4j2_logfile_size: "512 MB"
+#es_log4j2_logfile_max_count: 10

--- a/templates/log4j2.properties.j2
+++ b/templates/log4j2.properties.j2
@@ -14,11 +14,17 @@ appender.rolling.name = rolling
 appender.rolling.fileName = ${sys:es.logs}.log
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
-appender.rolling.filePattern = ${sys:es.logs}-%d{yyyy-MM-dd}.log
+appender.rolling.filePattern = ${sys:es.logs}-%d{yyyy-MM-dd}-%i.log
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
 appender.rolling.policies.time.modulate = true
+{% if es_log4j2_logfile_size_control == true %}
+appender.deprecation_rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.deprecation_rolling.policies.size.size = {{ es_log4j2_logfile_size }}
+appender.deprecation_rolling.strategy.type = DefaultRolloverStrategy
+appender.deprecation_rolling.strategy.max = {{ es_log4j2_logfile_max_count }}
+{% endif %}
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
… logfiles handled by Log4j2
Define size and count of ES main log-files for better control to avoid filesystem overflow.