### PR TITLE
override log4j2.properties with custom template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ es_templates: false
 es_user: elasticsearch
 es_group: elasticsearch
 es_config: {}
+es_config_log4j2: log4j2.properties.j2
 #Need to provide default directories
 es_pid_dir: "/var/run/elasticsearch"
 es_data_dirs: "/var/lib/elasticsearch"

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -48,7 +48,7 @@
 
 #Copy the logging.yml
 - name: Copy log4j2.properties File for Instance
-  template: src=log4j2.properties.j2 dest={{conf_dir}}/log4j2.properties owner={{ es_user }} group={{ es_group }} mode=0644 force=yes
+  template: src={{es_config_log4j2}} dest={{conf_dir}}/log4j2.properties owner={{ es_user }} group={{ es_group }} mode=0644 force=yes
   notify: restart elasticsearch
 
 - name: Copy jvm.options File for Instance


### PR DESCRIPTION
be able to override log4j2.properties with custom template using variable es_config_log4j2 as the template path