### PR TITLE
Remove default.path.home argument from version 5.4 and above

### DIFF
--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -87,7 +87,12 @@ fi
 # Define other required variables
 PID_FILE="$PID_DIR/$NAME.pid"
 DAEMON={{es_home}}/bin/elasticsearch
+
+{% if es_version | version_compare('5.4', '<') %}
 DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.home=$ES_HOME -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
+{% else %}
+DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
+{% endif %}
 
 export ES_JAVA_OPTS
 export JAVA_HOME


### PR DESCRIPTION
Removes default.path.home as it is no longer supported from version 5.4