### PR TITLE
Proxy Env Fix + New Gems + Testing tweaks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ provisioner:
   roles_path: ../
   require_ansible_repo: true
   ansible_verbose: true
-  ansible_version: 2.2.0
+  ansible_version: 2.3.2.0
   http_proxy: <%= ENV['HTTP_PROXY'] %>
   https_proxy: <%= ENV['HTTPS_PROXY'] %>
   no_proxy: localhost,127.0.0.1

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,8 +14,8 @@ provisioner:
   http_proxy: <%= ENV['HTTP_PROXY'] %>
   https_proxy: <%= ENV['HTTPS_PROXY'] %>
   no_proxy: localhost,127.0.0.1
-  ignore_extensions_from_root: [".git"]
-  ignore_paths_from_root: [".git"]
+  ignore_extensions_from_root: [".git",".idea",".kitchen.yml"]
+  ignore_paths_from_root: [".git",".idea",".kitchen"]
 
 platforms:
   - name: ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,8 +67,9 @@ platforms:
         - rm /etc/yum.repos.d/epel*repo /etc/yum.repos.d/puppetlabs-pc1.repo
         - yum -y install initscripts
         - yum clean all
+        - pip install --upgrade pip
         - pip install jmespath
-        - pip uninstall -y ansible
+        - yum -y remove ansible
       volume: <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
       run_command: "/usr/sbin/init"
       privileged: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,12 +6,16 @@ provisioner:
   name: ansible_playbook
   hosts: localhost
   roles_path: ../
-  require_ansible_repo: true
-  ansible_verbose: true
+  require_ansible_repo: false
+  require_ansible_omnibus: false
+  require_ansible_source: false
+  require_pip: true
   ansible_version: 2.3.2.0
   http_proxy: <%= ENV['HTTP_PROXY'] %>
   https_proxy: <%= ENV['HTTPS_PROXY'] %>
   no_proxy: localhost,127.0.0.1
+  ignore_extensions_from_root: [".git"]
+  ignore_paths_from_root: [".git"]
 
 platforms:
   - name: ubuntu-14.04
@@ -22,6 +26,7 @@ platforms:
         - apt-get update && apt-get install -y software-properties-common &&  add-apt-repository -y ppa:ansible/ansible
         - apt-get update && apt-get -y -q install python-apt python-pycurl python-pip
         - pip install jmespath
+        - pip uninstall -y ansible
       use_sudo: false
       volume: <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
   - name: ubuntu-16.04
@@ -33,6 +38,7 @@ platforms:
         - apt-get install -y -q net-tools
         - apt-get update && apt-get -y -q install python-apt python-pycurl python-pip
         - pip install jmespath
+        - pip uninstall -y ansible
       use_sudo: false
       volume: <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
       run_command: "/sbin/init"
@@ -43,11 +49,11 @@ platforms:
       provision_command:
         - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml curl wget
         - apt-get install -y -q net-tools
-        - apt-get install -y ansible
         - sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
         - sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
         - sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
         - pip install jmespath
+        - pip uninstall -y ansible
       volume: <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
       use_sudo: false
       run_command: "/sbin/init"
@@ -62,6 +68,7 @@ platforms:
         - yum -y install initscripts
         - yum clean all
         - pip install jmespath
+        - pip uninstall -y ansible
       volume: <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
       run_command: "/usr/sbin/init"
       privileged: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'test-kitchen', '1.8.0'
-gem "kitchen-docker", '2.5.0'
-gem 'kitchen-ansible', '0.44.6'
+gem 'test-kitchen', '1.17.0'
+gem "kitchen-docker", '2.6.0'
+gem 'kitchen-ansible', '0.47.3'
 gem 'net-ssh', '~> 3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'test-kitchen', '1.17.0'
-gem "kitchen-docker", '2.6.0'
+gem 'kitchen-docker', '2.6.0'
 gem 'kitchen-ansible', '0.47.3'
-gem 'net-ssh', '~> 3.0'
+gem 'net-ssh', '4.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     mixlib-versioning (1.2.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.2.0)
+    net-ssh (4.1.0)
     net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
     safe_yaml (1.0.4)
@@ -37,7 +37,7 @@ PLATFORMS
 DEPENDENCIES
   kitchen-ansible (= 0.47.3)
   kitchen-docker (= 2.6.0)
-  net-ssh (~> 3.0)
+  net-ssh (= 4.1.0)
   test-kitchen (= 1.17.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,44 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    artifactory (2.3.3)
-    kitchen-ansible (0.44.6)
-      net-ssh (~> 3.0)
+    artifactory (2.8.2)
+    kitchen-ansible (0.47.3)
+      mixlib-shellout (<= 2.2.7)
+      net-ssh (>= 3)
       test-kitchen (~> 1.4)
-    kitchen-docker (2.5.0)
+    kitchen-docker (2.6.0)
       test-kitchen (>= 1.0.0)
-    mixlib-install (1.1.0)
+    mixlib-install (2.1.12)
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-shellout (2.2.6)
-    mixlib-versioning (1.1.0)
+      thor
+    mixlib-shellout (2.2.7)
+    mixlib-versioning (1.2.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
+    net-ssh-gateway (1.3.0)
+      net-ssh (>= 2.6.5)
     safe_yaml (1.0.4)
-    test-kitchen (1.8.0)
-      mixlib-install (~> 1.0, >= 1.0.4)
+    test-kitchen (1.17.0)
+      mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
-      net-ssh (>= 2.9, < 4.0)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
       safe_yaml (~> 1.0)
-      thor (~> 0.18)
+      thor (~> 0.19, < 0.19.2)
     thor (0.19.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  kitchen-ansible (= 0.44.6)
-  kitchen-docker (= 2.5.0)
+  kitchen-ansible (= 0.47.3)
+  kitchen-docker (= 2.6.0)
   net-ssh (~> 3.0)
-  test-kitchen (= 1.8.0)
+  test-kitchen (= 1.17.0)
 
 BUNDLED WITH
-   1.11.2
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ansible role for 5.x Elasticsearch.  Currently this works on Debian and RedHat b
 * Debian 8
 * Centos 7
 
-The latest Elasticsearch versions of 5.x are actively tested.  **Only Ansible versions > 2.2.0 are supported.**
+The latest Elasticsearch versions of 5.x are actively tested.  **Only Ansible versions > 2.3.2 are supported, as this is currently the only version tested.**
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ To define proxy only for a particular plugin during its installation:
       proxy_port: 8080
 ```
 
-> For plugins installation, proxy_host and proxy_port are used first if they are defined and fallback to the global proxy settings if not.
+> For plugins installation, proxy_host and proxy_port are used first if they are defined and fallback to the global proxy settings if not. The same values are currently used for both the http and https proxy settings.
 
 ## Notes
 

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -48,7 +48,7 @@
     ES_INCLUDE: "{{ instance_default_file }}"
 
 - name: Install elasticsearch plugins
-  command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent {% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %}"
+  command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.plugin }} --batch --silent"
   register: plugin_installed
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
@@ -58,6 +58,7 @@
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
+    ES_JAVA_OPTS: "{% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -Dhttp.proxyHost={{ item.proxy_host }} -Dhttp.proxyPort={{ item.proxy_port }} -Dhttps.proxyHost={{ item.proxy_host }} -Dhttps.proxyPort={{ item.proxy_port }}  {% elif es_proxy_host is defined and es_proxy_host != '' %} -Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }} {% endif %}"
   until: plugin_installed.rc == 0
   retries: 5
   delay: 5

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -53,7 +53,7 @@
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins }}"
-  when: "{{ item.plugin in plugins_to_install }}"
+  when: item.plugin in plugins_to_install
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"

--- a/tasks/xpack/elasticsearch-xpack-install.yml
+++ b/tasks/xpack/elasticsearch-xpack-install.yml
@@ -28,7 +28,7 @@
 #Install plugin if not installed, or the es version has changed (so removed above), and its been requested
 - name: Install x-pack plugin
   command: >
-    {{es_home}}/bin/elasticsearch-plugin install --silent --batch x-pack {% if es_proxy_host is defined and es_proxy_host != '' %} -Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} {% endif %}
+    {{es_home}}/bin/elasticsearch-plugin install --silent --batch x-pack
   register: xpack_state
   failed_when: "'ERROR' in xpack_state.stdout"
   changed_when: xpack_state.rc == 0
@@ -37,3 +37,4 @@
   environment:
     CONF_DIR: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
+    ES_JAVA_OPTS: "{% if es_proxy_host is defined and es_proxy_host != '' %}-Dhttp.proxyHost={{ es_proxy_host }} -Dhttp.proxyPort={{ es_proxy_port }} -Dhttps.proxyHost={{ es_proxy_host }} -Dhttps.proxyPort={{ es_proxy_port }}{% endif %}"

--- a/test/integration/helpers/serverspec/standard_spec.rb
+++ b/test/integration/helpers/serverspec/standard_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples 'standard::init' do |es_version|
+shared_examples 'standard::init' do |es_version,plugins|
 
   describe user('elasticsearch') do
     it { should exist }
@@ -74,6 +74,18 @@ shared_examples 'standard::init' do |es_version|
   describe file('/etc/elasticsearch/logging.yml') do
     it { should_not exist }
   end
+
+  for plugin in plugins
+    describe file('/usr/share/elasticsearch/plugins/'+plugin) do
+      it { should be_directory }
+      it { should be_owned_by 'elasticsearch' }
+    end
+    #confirm plugins are installed and the correct version
+    describe command('curl -s localhost:9200/_nodes/plugins | grep \'"name":"'+plugin+'","version":"'+es_version+'"\'') do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+
 
 end
 

--- a/test/integration/standard-5x/serverspec/default_spec.rb
+++ b/test/integration/standard-5x/serverspec/default_spec.rb
@@ -2,7 +2,7 @@ require 'standard_spec'
 
 
 describe 'Standard Tests v 5.x' do
-  include_examples 'standard::init', "5.2.2"
+  include_examples 'standard::init', "5.2.2", ["ingest-geoip"]
 end
 
 


### PR DESCRIPTION
A number of changes here:

1. I've updated the gems and testing infrastructure to the latest version.
1. We now remove ansible from all of the provided images and use ansible kitchen's support for installing a specific version -  2.3.2.0
1. Updated the version we test against to 2.3.2.0
1. Changed the proxy specification as per [ this PR](https://github.com/elastic/ansible-elasticsearch/pull/284) from @jdlourenco. I've used the official environment support which simplifies our commands nicely.
1. Standard test now checks for ingest-geoip.

This has been tested locally. Working on new test infrastructure.
