### PR TITLE
Simpler restart handling + issue-test for recreation of problems

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -111,3 +111,9 @@ suites:
     provisioner:
       playbook: test/integration/xpack-standard.yml
       idempotency_test: true
+  - name: issue-test
+    run_list:
+    attributes:
+    provisioner:
+      playbook: test/integration/issue-test.yml
+      idempotency_test: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,5 +9,4 @@
   when:
     - es_restart_on_change
     - es_start_service
-    - ((plugin_installed is defined and plugin_installed.changed) or (config_updated is defined and config_updated.changed) or (xpack_state.changed) or (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed or elasticsearch_install_from_package.changed))
   register: es_restarted

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -28,6 +28,7 @@
   apt: name=elasticsearch{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %} state=present force={{force_install}} allow_unauthenticated={{ 'no' if es_apt_key else 'yes' }} cache_valid_time=86400
   when: es_use_repository
   register: debian_elasticsearch_install_from_repo
+  notify: restart elasticsearch
 
 - name: Debian - Download elasticsearch from url
   get_url: url={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.deb{% endif %} dest=/tmp/elasticsearch-{{ es_version }}.deb validate_certs=no
@@ -37,3 +38,4 @@
   apt: deb=/tmp/elasticsearch-{{ es_version }}.deb
   when: not es_use_repository
   register: elasticsearch_install_from_package
+  notify: restart elasticsearch

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -15,6 +15,7 @@
   yum: name=elasticsearch{% if es_version is defined and es_version != ""  %}-{{ es_version }}{% endif %} state=present update_cache=yes
   when: es_use_repository
   register: redhat_elasticsearch_install_from_repo
+  notify: restart elasticsearch
   until: '"failed" not in redhat_elasticsearch_install_from_repo'
   retries: 5
   delay: 10
@@ -23,3 +24,4 @@
   yum: name={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.noarch.rpm{% endif %} state=present
   when: not es_use_repository
   register: elasticsearch_install_from_package
+  notify: restart elasticsearch

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -18,7 +18,7 @@
 #Copy the config template
 - name: Copy Configuration File
   template: src=elasticsearch.yml.j2 dest={{conf_dir}}/elasticsearch.yml owner={{ es_user }} group={{ es_group }} mode=0644 force=yes
-  register: config_updated
+  register: system_change
   notify: restart elasticsearch
 
 #Copy the instance specific default file

--- a/tasks/elasticsearch-optional-user.yml
+++ b/tasks/elasticsearch-optional-user.yml
@@ -1,6 +1,8 @@
 ---
 #Add the elasticsearch user before installing from packages.
 - name: Ensure optional elasticsearch group is created with the correct id.
+  #Restart if these change
+  notify: restart elasticsearch
   group:
     state: present
     name: "{{ es_group }}"
@@ -8,6 +10,8 @@
     gid: "{{ es_group_id }}"
 
 - name: Ensure optional elasticsearch user is created with the correct id.
+  #Restart if these change
+  notify: restart elasticsearch
   user:
     state: present
     name: "{{ es_user }}"

--- a/test/integration/helpers/serverspec/issue_test_spec.rb
+++ b/test/integration/helpers/serverspec/issue_test_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+shared_examples 'issue_test::init' do |es_version,plugins|
+
+  #Add custom tests here for the issue-test.yml test
+
+end
+

--- a/test/integration/issue-test.yml
+++ b/test/integration/issue-test.yml
@@ -1,0 +1,12 @@
+#This file is for users to test issues and reproduce them using the test framework.
+#Modify the playbook  below and test with kitchen i.e. `kitchen test issue-test`
+#To add custom tests modify the serverspec file ./helpers/serverspec/issue_test_spec.rb
+#Idempot test is enabled for this test
+- name: Simple Example
+  hosts: localhost
+  remote_user: root
+  become: yes
+  become_method: sudo
+  roles:
+    - { role: elasticsearch, es_instance_name: "node1" }
+  vars:

--- a/test/integration/issue-test/issue-test.yml
+++ b/test/integration/issue-test/issue-test.yml
@@ -1,0 +1,2 @@
+---
+- host: test-kitchen

--- a/test/integration/issue-test/serverspec/default_spec.rb
+++ b/test/integration/issue-test/serverspec/default_spec.rb
@@ -1,0 +1,6 @@
+require 'issue_test_spec'
+
+describe 'Issue Test' do
+  include_examples 'issue_test::init', "5.5.1", []
+end
+


### PR DESCRIPTION
This PR simplifies the restart logic, relying on the restart handler only. We now notify the handler consistently and remove the additional checks.

This should close the following issues:

https://github.com/elastic/ansible-elasticsearch/issues/305
https://github.com/elastic/ansible-elasticsearch/issues/315

All tests pass locally. 

I have also added issue-test.yml.  This test will not be included in the new automated tests, but allows us to easily test playbooks for user issues. I'll add instructions once we have the automated test suite - users can in theory then issue a PR with a playbook in the test-issue.yml and immediately demonstrate the failure.

@barryib @jpcarey i believe this simplifies restarts significantly. 