### PR TITLE
set "check_mode: no" when computing installed_plugins so that ansible…

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -15,6 +15,7 @@
   shell: "ls {{es_home}}/plugins {{list_command}}"
   register: installed_plugins
   changed_when: False
+  check_mode: no
   ignore_errors: yes
   environment:
     CONF_DIR: "{{ conf_dir }}"


### PR DESCRIPTION
set "check_mode: no" when computing installed_plugins so that ansible-playbook can succeed when in check mode (-C)