### PR TITLE
Allow to change directory name generation strategy so inventory_hostn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,12 @@ To define proxy only for a particular plugin during its installation:
 
 > For plugins installation, proxy_host and proxy_port are used first if they are defined and fallback to the global proxy settings if not.
 
+### Unique directory names
+
+If for some reason you do not want the `inventory_hostname` to be used as part of the directory names set `es_unique_dir_names` to `false`.
+
+This might be handy if the storage is frequently attached to a new node, with a different `inventory_hostname`. 
+
 ## Notes
 
 * The role assumes the user/group exists on the server.  The elasticsearch packages create the default elasticsearch user.  If this needs to be changed, ensure the user exists.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ es_max_open_files: 65536
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: []
+es_unique_dir_names: true
 #These are used for internal operations performed by ansible.
 #They do not effect the current configuration
 es_api_host: "localhost"

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -15,7 +15,7 @@
   yum: name=elasticsearch{% if es_version is defined and es_version != ""  %}-{{ es_version }}{% endif %} state=present update_cache=yes
   when: es_use_repository
   register: redhat_elasticsearch_install_from_repo
-  until: '"failed" not in redhat_elasticsearch_install_from_repo'
+  until: redhat_elasticsearch_install_from_repo.rc == 0
   retries: 5
   delay: 10
 

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -48,6 +48,11 @@
 #For directories we also use the {{inventory_hostname}}-{{ es_instance_name }} - this helps if we have a shared SAN.
 
 - set_fact: instance_suffix={{inventory_hostname}}-{{ es_instance_name }}
+  when: es_unique_dir_names
+
+- set_fact: instance_suffix={{ es_instance_name }}
+  when: not es_unique_dir_names
+
 - set_fact: pid_dir={{ es_pid_dir }}/{{instance_suffix}}
 - set_fact: log_dir={{ es_log_dir }}/{{instance_suffix}}
 - set_fact: work_dir={{ es_work_dir }}/{{instance_suffix}}


### PR DESCRIPTION
We hit a case on AWS that we lose all of the data when the instance is upgraded and the old storage attached to the new one. Upon running the provisioning the directory name changes.

Provides a fix for elastic/ansible-elasticsearch#384