### PR TITLE
Parameterize timeout value for ES startup in Debian SysV init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ In addition to es_config, the following parameters allow the customization of th
 * ```es_max_map_count``` maximum number of VMA (Virtual Memory Areas) a process can own. Defaults to 262144.
 * ```es_max_open_files``` the maximum file descriptor number that can be opened by this process. Defaults to 65536.
 * ```es_max_threads``` the maximum number of threads the process can start. Defaults to 2048 (the minimum required by elasticsearch).
+* ```es_debian_startup_timeout``` how long Debian-family SysV init scripts wait for the service to start, in seconds. Defaults to 10 seconds.
 
 Earlier examples illustrate the installation of plugins using `es_plugins`.  For officially supported plugins no version or source delimiter is required. The plugin script will determine the appropriate plugin version based on the target Elasticsearch version.  For community based plugins include the full url.  This approach should NOT be used for the X-Pack plugin.  See X-Pack below for details here.
  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ es_xpack_features: ["alerting","monitoring","graph","ml","security"]
 #They do not effect the current configuration
 es_api_host: "localhost"
 es_api_port: 9200
+es_debian_startup_timeout: 10
 
 # Since ansible 2.2 the following variables need to be defined
 # to allow the role to be conditionally played with a when condition.

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -165,7 +165,7 @@ case "$1" in
 	return=$?
 	if [ $return -eq 0 ]; then
 		i=0
-		timeout=10
+		timeout={{es_debian_startup_timeout}}
 		# Wait for the process to be properly started before exiting
 		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
 		do


### PR DESCRIPTION
Simple, backwards-compatible change, to allow for other timeout values for node startup than the hard coded 10 seconds in Debian SysV init scripts. No other managed startup script/scheme seems to enforce a similar startup timeout, so only changed here.

Motivation: one of my 8 boxes that make up a cluster takes 11 seconds to startup, and the ansible run always fails due to this.