### PR TITLE
Fix RedHat install - until condition was not correct

### DIFF
--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -19,7 +19,7 @@
   when: es_use_repository
   register: redhat_elasticsearch_install_from_repo
   notify: restart elasticsearch
-  until: not redhat_elasticsearch_install_from_repo.failed
+  until: redhat_elasticsearch_install_from_repo.rc == 0
   retries: 5
   delay: 10
 

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -19,7 +19,7 @@
   when: es_use_repository
   register: redhat_elasticsearch_install_from_repo
   notify: restart elasticsearch
-  until: '"failed" not in redhat_elasticsearch_install_from_repo'
+  until: not redhat_elasticsearch_install_from_repo.failed
   retries: 5
   delay: 10
 


### PR DESCRIPTION
I was getting

`fatal: [redacted_hostname]: FAILED! => {"attempts": 5, "changed": false, "failed": true, "msg": "", "rc": 0, "results": ["elasticsearch-6.2.1-1.noarch providing elasticsearch is already installed"]}`

because „failed” was all the time present in the response.