### PR TITLE
elasticsearch.yml: xpack settings added only if es_enable_xpack

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -23,6 +23,7 @@ path.data: {{ data_dirs | array_to_str }}
 
 path.logs: {{ log_dir }}
 
+{% if es_enable_xpack %}
 {% if not "security" in es_xpack_features %}
 xpack.security.enabled: false
 {% endif %}
@@ -41,4 +42,5 @@ xpack.ml.enabled: false
 
 {% if not "graph" in es_xpack_features %}
 xpack.graph.enabled: false
+{% endif %}
 {% endif %}


### PR DESCRIPTION
the default values are:
 - es_enable_xpack: false
 - es_xpack_features: ["alerting","monitoring","graph","ml","security"]

With the default values, XPACK is not installed
But the generated elasticsearch.yml contains the XPACK Settings.
Elasticsearch application refuses to start with these unknown settings