### PR TITLE
auth fix by reordering set_fact on es_api_basic_auth_password

### DIFF
--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -16,7 +16,31 @@
   set_fact: manage_native_roles=true
   when: es_roles is defined and es_roles.native is defined and es_roles.native.keys() | length > 0
 
+- name: set fact native_users
+  set_fact: native_users={{ es_users.native }}
+  when: manage_native_users
+
 #If the node has just has security installed it maybe either stopped or started 1. if stopped, we need to start to load native realms 2. if started, we need to restart to load
+
+# Try to list current users with the defined es_api_basic_auth_password
+- name: Try list Native Users
+  uri:
+    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user
+    method: GET
+    user: "{{es_api_basic_auth_username}}"
+    password: "{{es_api_basic_auth_password}}"
+    force_basic_auth: yes
+    status_code: 200
+  changed_when: False
+  failed_when: False
+  register: try_native_api_password
+  when: manage_native_users
+
+# otherwise try using the native defined one in es_users.native
+- set_fact: es_api_basic_auth_password={{native_users[es_api_basic_auth_username].password}}
+  when:
+    - try_native_api_password.status == 401
+    - es_api_basic_auth_username in native_users
 
 #List current users
 - name: List Native Users
@@ -40,10 +64,6 @@
   when: manage_native_users
 
 #We are changing the es_api_basic_auth_username password, so we need to do it first and update the param
-- name: set fact native_users
-  set_fact: native_users={{ es_users.native }}
-  when: manage_native_users
-
 - name: set fact change_api_password to true
   set_fact: change_api_password=true
   when: manage_native_users and es_api_basic_auth_username in native_users and native_users[es_api_basic_auth_username].password is defined
@@ -60,6 +80,7 @@
     force_basic_auth: yes
   when: change_api_password
 
+# We changed the es_api_basic_auth_username password, so we now need to use the newly defined one
 - name: set fact es_api_basic_auth_password
   set_fact: es_api_basic_auth_password={{native_users[es_api_basic_auth_username].password}}
   when: change_api_password


### PR DESCRIPTION
5.6.x with xpack security enabled: there may be some API auth issues when adding new members, also some idempotency issues on subsequent runs

With 6.x, the new method to setup password of elastic built-in user works perfectly;
but it looks like with 5.x, after initial setup there maybe some issues determining the correct password to use for API access.

This PR add a first try with the default 'changeme' password then switch to the native user password defined in es_users.native, this allows subsequent run with a non default password and also adding members after using the default creds before setting up native user/password

attached are the playbooks for 6.2.2 and 5.6.8 and an inventory file for a basic cluster

[playbook.5.6.8.yml.txt](https://github.com/elastic/ansible-elasticsearch/files/1781394/playbook.5.6.8.yml.txt)
[playbook.6.2.2.yml.txt](https://github.com/elastic/ansible-elasticsearch/files/1781396/playbook.6.2.2.yml.txt)
[inventory.txt](https://github.com/elastic/ansible-elasticsearch/files/1781397/inventory.txt)
