### PR TITLE
Add a ES6 compatibility mode so that we can deploy ES6 configuration in ES 5.6 cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,15 @@ To define proxy only for a particular plugin during its installation:
 
 > For plugins installation, proxy_host and proxy_port are used first if they are defined and fallback to the global proxy settings if not. The same values are currently used for both the http and https proxy settings.
 
+### Migration to ES6
+
+If you want to the configuration files / options compliant with ES6 (for example to check with Kibana cluster checkup), set the parameter es6_migration_mode. It currently manages the following elements : 
+
+* Remove path.conf from elasticsearch.yml
+* Remove default.path.data, default.path.logs, default.path.conf from your launcher (made for debian, redhat and systemd scripts)
+
+It is working at least with ElasticSearch 5.6.x
+
 ## Notes
 
 * The role assumes the user/group exists on the server.  The elasticsearch packages create the default elasticsearch user.  If this needs to be changed, ensure the user exists.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,5 @@ conf_dir: ''
 data_dirs: ''
 # JVM custom parameters
 es_jvm_custom_parameters: ''
+# Compatibility mode for es6
+es6_migration_mode: false

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -15,7 +15,7 @@ node.name: {{inventory_hostname}}-{{es_instance_name}}
 
 # Path to directory containing configuration (this file and logging.yml):
 
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if ((not es6_migration_mode) and (es_version | version_compare('6.0.0', '<'))) %}
 path.conf: {{ conf_dir }}
 {% endif %}
 

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -92,7 +92,7 @@ fi
 # Define other required variables
 PID_FILE="$PID_DIR/$NAME.pid"
 DAEMON=$ES_HOME/bin/elasticsearch
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if ((not es6_migration_mode) and (es_version | version_compare('6.0.0', '<'))) %}
 DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
 {% else %}
 DAEMON_OPTS="-d -p $PID_FILE"

--- a/templates/init/redhat/elasticsearch.j2
+++ b/templates/init/redhat/elasticsearch.j2
@@ -140,7 +140,7 @@ start() {
     cd $ES_HOME
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if ((not es6_migration_mode) and (es_version | version_compare('6.0.0', '<'))) %}
     daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR
 {% else %}
     daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -24,7 +24,7 @@ ExecStartPre=/usr/share/elasticsearch/bin/elasticsearch-systemd-pre-exec
 
 ExecStart={{es_home}}/bin/elasticsearch \
                                     -p ${PID_DIR}/elasticsearch.pid \
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if ((not es6_migration_mode) and (es_version | version_compare('6.0.0', '<'))) %}
                                     -Edefault.path.logs=${LOG_DIR} \
                                     -Edefault.path.data=${DATA_DIR} \
                                     -Edefault.path.conf=${CONF_DIR} \


### PR DESCRIPTION
I would like to have the possibility to validate the ES configuration on ES 5.6 before the migration to ES6. 
So I created a migration mode that can be activated on demand to have a configuration compliant to ES6 migration.