### PR TITLE
Update elasticsearch-xpack.yml

### DIFF
--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: set fact es_version_changed
-  set_fact: es_version_changed={{ ((elasticsearch_install_from_package is defined and (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed)) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) }}
+  set_fact: es_version_changed={{ ((elasticsearch_install_from_package is defined and ((debian_elasticsearch_install_from_repo is defined and debian_elasticsearch_install_from_repo.changed) or (redhat_elasticsearch_install_from_repo is defined and redhat_elasticsearch_install_from_repo.changed))) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) }}
 
 - name: include elasticsearch-xpack-install.yml
   include: elasticsearch-xpack-install.yml


### PR DESCRIPTION
Original fact setting fails on update plays for Debian with : redhat_elasticsearch_install_from_repo is undefined.

Updated the conditional to allow multiple plays.