### PR TITLE
require admin role to use update-alternatives

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -14,6 +14,7 @@
 
 - name: Get the installed java path
   shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0"
+  become: yes
   register: java_full_path
   failed_when: False
   changed_when: False


### PR DESCRIPTION
promote `update-alternatives` command to run as admin role

I have problem when i tried to run this ansible script to Google Compute Engine
It show below error
```
TASK [elasticsearch : correct java version selected] *****************************************************************************
fatal: [35.186.157.183]: FAILED! => {"changed": false, "failed": true, "msg": "Specified path  does not exist"}
        to retry, use: --limit @/.../Projects/ansible-elasticsearch/site.retry
```

After debug, it's because `java_full_path` has empty value because `update-alternatives` got error but hidden by `failed_when: False`

It look like, `update-alternatives` need to run by admin role