### PR TITLE
Add jenkins test matrix yml definition

### DIFF
--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -1,0 +1,16 @@
+VERSION:
+  - 6.x
+  - 5.x
+OS:
+  - ubuntu-1404
+  - ubuntu-1604
+  - debian-8
+  - centos-7
+TEST_TYPE:
+  - standard
+  - package
+  - config
+  - multi
+  - xpack
+  - xpack-standard
+  - issue-test


### PR DESCRIPTION
This allows us to control and modify the jenkins matrix job via the pull
request flow instead of needing to sync changes in the jenkins
configuration.

I originally added it in the 6.3 support PR with a commit message but I apparently didn't check in the file :S https://github.com/elastic/ansible-elasticsearch/pull/452/commits/c1b83a892f0cac80203b9bc858ae09a1a5f35414