### PR TITLE
Add test for upgrading from previous version of oss to current

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,7 +41,6 @@ platforms:
       use_sudo: false
       volume: 
         - <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
-        - /etc/elasticsearch
   - name: ubuntu-16.04
     driver_config:
       image: dliappis/ubuntu-devopsci:16.04
@@ -55,7 +54,6 @@ platforms:
       use_sudo: false
       volume: 
         - <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
-        - /etc/elasticsearch
       run_command: "/sbin/init"
   - name: debian-8
     driver_config:
@@ -71,7 +69,6 @@ platforms:
         - pip uninstall -y ansible
       volume: 
         - <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
-        - /etc/elasticsearch
       use_sudo: false
       run_command: "/sbin/init"
   - name: centos-7
@@ -88,7 +85,6 @@ platforms:
         - pip install jmespath
       volume: 
         - <%=ENV['ES_XPACK_LICENSE_FILE']%>:/tmp/license.json
-        - /etc/elasticsearch
       run_command: "/usr/sbin/init"
       privileged: true
       use_sudo: false
@@ -132,4 +128,10 @@ suites:
     attributes:
     provisioner:
       playbook: test/integration/issue-test.yml
+      idempotency_test: false
+  - name: oss-upgrade
+    run_list:
+    attributes:
+    provisioner:
+      playbook: test/integration/oss-upgrade.yml
       idempotency_test: false

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -25,6 +25,31 @@
     - { repo: "{{ es_apt_url }}", state: "present" }
   when: es_use_repository
 
+
+- name: Gracefully stop and remove elasticsearch if we are switching to the oss version
+  when:
+    - es_package_name == 'elasticsearch-oss'
+  block:
+  - name: Check if the elasticsearch package is installed
+    shell: dpkg-query -W -f'${Status}' elasticsearch
+    register: elasticsearch_package
+    failed_when: False
+    changed_when: False
+
+  - name: stop elasticsearch
+    become: yes
+    service:
+      name: '{{ instance_init_script | basename }}'
+      state: stopped
+    when: elasticsearch_package.stdout == 'install ok installed'
+
+  - name: Debian - Remove elasticsearch package if we are installing the oss package
+    become: yes
+    apt:
+      name: 'elasticsearch'
+      state: absent
+    when: elasticsearch_package.stdout == 'install ok installed'
+
 - name: Debian - Ensure elasticsearch is installed
   become: yes
   apt:

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -13,6 +13,13 @@
   include: elasticsearch-RedHat-version-lock.yml
   when: es_version_lock
 
+- name: RedHat - Remove non oss package if the old elasticsearch package is installed
+  become: yes
+  yum:
+    name: 'elasticsearch'
+    state: 'absent'
+  when: es_package_name == 'elasticsearch-oss'
+
 - name: RedHat - Install Elasticsearch
   become: yes
   yum:

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -86,9 +86,29 @@
     content: ''
   when: ansible_os_family == 'RedHat'
 
-- name: Delete Default Sysconfig File
+- name: Check if default systemd file exists
+  stat:
+    path: "{{ sysd_script }}"
+  register: sysd_stat_result
+
+- name: Remove if it is a normal file
+  file:
+    path: "{{ sysd_script }}"
+    state: absent
+  when: not sysd_stat_result.stat.islnk
+
+- name: Create a symbolic link to the default systemd location to the first instance running on this host
   become: yes
-  file: dest="{{ sysd_script }}" state=absent
+  file:
+    state: link
+    src: "{{ instance_sysd_script }}"
+    path: "{{ sysd_script }}"
+  when:
+  - use_system_d
+  - not sysd_stat_result.stat.islnk
+  notify:
+  - reload systemd configuration
+  - restart elasticsearch
 
 - name: Delete Default Configuration File
   become: yes

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -86,29 +86,30 @@
     content: ''
   when: ansible_os_family == 'RedHat'
 
-- name: Check if default systemd file exists
-  stat:
-    path: "{{ sysd_script }}"
-  register: sysd_stat_result
-
-- name: Remove if it is a normal file
-  file:
-    path: "{{ sysd_script }}"
-    state: absent
-  when: not sysd_stat_result.stat.islnk
-
-- name: Create a symbolic link to the default systemd location to the first instance running on this host
-  become: yes
-  file:
-    state: link
-    src: "{{ instance_sysd_script }}"
-    path: "{{ sysd_script }}"
-  when:
-  - use_system_d
-  - not sysd_stat_result.stat.islnk
-  notify:
-  - reload systemd configuration
-  - restart elasticsearch
+- name: Symlink default systemd service to first instance of elasticsearch
+  when: use_system_d
+  block:
+  - name: Check if default systemd file exists
+    stat:
+      path: "{{ sysd_script }}"
+    register: sysd_stat_result
+  
+  - name: Remove if it is a normal file
+    file:
+      path: "{{ sysd_script }}"
+      state: absent
+    when: not sysd_stat_result.stat.islnk
+  
+  - name: Create a symbolic link to the default systemd location to the first instance running on this host
+    become: yes
+    file:
+      state: link
+      src: "{{ instance_sysd_script }}"
+      path: "{{ sysd_script }}"
+    when: not sysd_stat_result.stat.islnk
+    notify:
+    - reload systemd configuration
+    - restart elasticsearch
 
 - name: Delete Default Configuration File
   become: yes

--- a/test/integration/helpers/serverspec/config_spec.rb
+++ b/test/integration/helpers/serverspec/config_spec.rb
@@ -125,10 +125,6 @@ shared_examples 'config::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end

--- a/test/integration/helpers/serverspec/multi_spec.rb
+++ b/test/integration/helpers/serverspec/multi_spec.rb
@@ -212,10 +212,6 @@ shared_examples 'multi::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end
@@ -223,18 +219,5 @@ shared_examples 'multi::init' do |vars|
   describe file('/etc/elasticsearch/logging.yml') do
     it { should_not exist }
   end
-
-
-  #Test server spec file has been created and modified - currently not possible as not copied for debian 8
-  #describe file('/usr/lib/systemd/system/master_elasticsearch.service') do
-  #  it { should be_file }
-  #  it { should contain 'LimitMEMLOCK=infinity' }
-  #end
-
-  #describe file('/usr/lib/systemd/system/node1_elasticsearch.service') do
-  #  it { should be_file }
-  #  it { should_not contain 'LimitMEMLOCK=infinity' }
-  #end
-
 end
 

--- a/test/integration/helpers/serverspec/oss_upgrade_spec.rb
+++ b/test/integration/helpers/serverspec/oss_upgrade_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+shared_examples 'oss_upgrade::init' do |vars|
+  describe 'version check' do
+    it 'should be reported as version '+vars['es_version'] do
+      expect(curl_json('http://localhost:9200')['version']['number']).to eq(vars['es_version'])
+    end
+  end
+end

--- a/test/integration/helpers/serverspec/package_spec.rb
+++ b/test/integration/helpers/serverspec/package_spec.rb
@@ -100,10 +100,6 @@ shared_examples 'package::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end

--- a/test/integration/helpers/serverspec/standard_spec.rb
+++ b/test/integration/helpers/serverspec/standard_spec.rb
@@ -72,10 +72,6 @@ shared_examples 'standard::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end

--- a/test/integration/helpers/serverspec/xpack_spec.rb
+++ b/test/integration/helpers/serverspec/xpack_spec.rb
@@ -68,10 +68,6 @@ shared_examples 'xpack::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end

--- a/test/integration/helpers/serverspec/xpack_standard_spec.rb
+++ b/test/integration/helpers/serverspec/xpack_standard_spec.rb
@@ -69,10 +69,6 @@ shared_examples 'xpack_standard::init' do |vars|
     end
   end
 
-  describe file('/usr/lib/systemd/system/elasticsearch.service') do
-    it { should_not exist }
-  end
-
   describe file('/etc/elasticsearch/elasticsearch.yml') do
     it { should_not exist }
   end

--- a/test/integration/oss-upgrade.yml
+++ b/test/integration/oss-upgrade.yml
@@ -1,0 +1,21 @@
+---
+- name: Standard test for single node setup. Tests idempotence.
+  hosts: localhost
+  tasks:
+    - include: elasticsearch/test/integration/debug.yml
+  roles:
+    - { role: elasticsearch, es_instance_name: "node1" }
+  vars:
+    es_version: "{{ '6.2.4' if es_major_version == '6.x' else '5.6.9' }}" # This is set to an older version than the current default to force an upgrade
+    es_enable_xpack: false
+    es_heap_size: "1g"
+
+- name: Standard test for single node setup. Tests idempotence.
+  hosts: localhost
+  tasks:
+    - include: elasticsearch/test/integration/debug.yml
+  roles:
+    - { role: elasticsearch, es_instance_name: "node1" }
+  vars:
+    es_enable_xpack: false
+    es_heap_size: "1g"

--- a/test/integration/oss-upgrade/oss-upgrade.yml
+++ b/test/integration/oss-upgrade/oss-upgrade.yml
@@ -1,0 +1,2 @@
+---
+- host: test-kitchen

--- a/test/integration/oss-upgrade/serverspec/default_spec.rb
+++ b/test/integration/oss-upgrade/serverspec/default_spec.rb
@@ -1,0 +1,7 @@
+require 'oss_upgrade_spec'
+require 'json'
+vars = JSON.parse(File.read('/tmp/vars.json'))
+
+describe 'oss upgrade Tests' do
+  include_examples 'oss_upgrade::init', vars
+end

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -14,3 +14,4 @@ TEST_TYPE:
   - xpack
   - xpack-standard
   - issue-test
+  - oss-upgrade


### PR DESCRIPTION
This PR adds an automated test to make sure that upgrading from elasticsearch without xpack to 6.3 oss works as expected (it wasn't so the fixes are also included in this pr).

Next PR will be making sure the upgrade path from 6.2 oss to 6.3 xpack is also working properly. 

Right now we are testing the following:

6.2 oss -> 6.3 oss (this PR)
6.2 xpack -> 6.3 xpack (the "xpack" test suite does this)

Todo:

6.2 oss -> 6.3 xpack


Once all of the upgrade paths test are in place and 6.3 has been released I'm going to remove the other test suites which aren't really doing to much. The final set of suites will look something like

oss
xpack
oss-upgrade
xpack-upgrade
oss-to-xpack-upgrade
multi