### PR TITLE
Fix systemd stat symlink

### DIFF
--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -86,29 +86,18 @@
     content: ''
   when: ansible_os_family == 'RedHat'
 
+  # We need the force parameter to be able to overwrite the default non-link file
 - name: Symlink default systemd service to first instance of elasticsearch
   when: use_system_d
-  block:
-  - name: Check if default systemd file exists
-    stat:
-      path: "{{ sysd_script }}"
-    register: sysd_stat_result
-
-  - name: Remove if it is a normal file
-    file:
-      path: "{{ sysd_script }}"
-      state: absent
-    when: sysd_stat_result.stat.exists and not sysd_stat_result.stat.islnk
-
-  - name: Create a symbolic link to the default systemd location to the first instance running on this host
-    become: yes
-    file:
-      state: link
-      src: "{{ instance_sysd_script }}"
-      path: "{{ sysd_script }}"
-    notify:
-    - reload systemd configuration
-    - restart elasticsearch
+  become: yes
+  file:
+    state: link
+    force: yes
+    src: "{{ instance_sysd_script }}"
+    path: "{{ sysd_script }}"
+  notify:
+  - reload systemd configuration
+  - restart elasticsearch
 
 - name: Delete Default Configuration File
   become: yes

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -86,18 +86,30 @@
     content: ''
   when: ansible_os_family == 'RedHat'
 
-  # We need the force parameter to be able to overwrite the default non-link file
 - name: Symlink default systemd service to first instance of elasticsearch
   when: use_system_d
-  become: yes
-  file:
-    state: link
-    force: yes
-    src: "{{ instance_sysd_script }}"
-    path: "{{ sysd_script }}"
-  notify:
-  - reload systemd configuration
-  - restart elasticsearch
+  block:
+  - name: Check if default systemd file exists
+    stat:
+      path: "{{ sysd_script }}"
+    register: sysd_stat_result
+
+  - name: Remove if it is a normal file
+    file:
+      path: "{{ sysd_script }}"
+      state: absent
+    when: sysd_stat_result.stat.exists and not sysd_stat_result.stat.islnk
+
+  - name: Create a symbolic link to the default systemd location to the first instance running on this host
+    become: yes
+    file:
+      state: link
+      src: "{{ instance_sysd_script }}"
+      path: "{{ sysd_script }}"
+    when: sysd_stat_result.stat.exists and not sysd_stat_result.stat.islnk
+    notify:
+    - reload systemd configuration
+    - restart elasticsearch
 
 - name: Delete Default Configuration File
   become: yes

--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -93,20 +93,19 @@
     stat:
       path: "{{ sysd_script }}"
     register: sysd_stat_result
-  
+
   - name: Remove if it is a normal file
     file:
       path: "{{ sysd_script }}"
       state: absent
-    when: not sysd_stat_result.stat.islnk
-  
+    when: sysd_stat_result.stat.exists and not sysd_stat_result.stat.islnk
+
   - name: Create a symbolic link to the default systemd location to the first instance running on this host
     become: yes
     file:
       state: link
       src: "{{ instance_sysd_script }}"
       path: "{{ sysd_script }}"
-    when: not sysd_stat_result.stat.islnk
     notify:
     - reload systemd configuration
     - restart elasticsearch


### PR DESCRIPTION
<!-- Bug report -->
## Issue

**Elasticsearch version**: `6.3.0`

**Role version**: `6.3.0`

**JVM version** (`java -version`):
```
java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 1.8.0_171-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.171-b11, mixed mode)
```

**OS version** (`uname -a` if on a Unix-like system):
```
Linux hostname 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux
```

**Ansible version** : 
```
ansible 2.5.5
  config file = None
  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]
```
**Description of the problem including expected versus actual behaviour**:

When deploying with systemd (`use_system_d` is set to true by the playbook, default behaviour on Debian 8 and above), if the elasticsearch systemd unit file does not exist, the playbook fails instead of creating it as a symlink.

**Playbook**:
The playbook we actually played is quite complicated, and was run number of times to overcome the numerous issues we met during an upgrade from ElasticSearch 5.6.2 to 6.3.0.


The following playbook however reproduces the issue we met : 
```
- hosts: localhost
  tasks:
    # Setup
    - name: Create a dummy source file
      file:
        path: source
        state: touch

    - name: Make sure dest file doesn't exist
      file:
        path: dest
        state: absent

    # Issue reproduction
    - name: Check if dest file exists
      stat:
        path: dest
      register: stat_result

    - name: Remove if it is a normal file
      file:
        path: dest
        state: absent
      when: not stat_result.stat.islnk

    - name: Create a symlink
      file:
        state: link
        src: source
        path: dest
      when: not stat_result.stat.islnk
```

**Provide logs from Ansible**:
The above playbook gives the exact same error than the real one (except for the file paths), which is : 
```
PLAY [localhost] ******************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************
ok: [localhost]

TASK [Create a dummy source file] *************************************************************************************************************************************
changed: [localhost]

TASK [Make sure dest file doesn't exist] ******************************************************************************************************************************
ok: [localhost]

TASK [Check if dest file exists] **************************************************************************************************************************************
ok: [localhost]

TASK [Remove if it is a normal file] **********************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'not stat_result.stat.islnk' failed. The error was: error while evaluating conditional (not stat_result.stat.islnk): 'dict object' has no attribute 'islnk'\n\nThe error appears to have been in '/home/user/test_playbook.yml': line 20, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Remove if it is a normal file\n      ^ here\n"}
        to retry, use: --limit @/home/user/test_playbook.retry

PLAY RECAP ************************************************************************************************************************************************************
localhost                  : ok=4    changed=1    unreachable=0    failed=1
```

## Proposed fix

According to the [stat module documentation](https://docs.ansible.com/ansible/latest/modules/stat_module.html#return-values), most values in the return dict, including `islnk` are only defined if the target file exists. When it doesn't, the current code checks a non-existing dict entry, and ansible fails.

I can't explain with certitude why we ended up with no systemd unit file in the first place, but it is definitely possible (happened at some point of the upgrade on every single node we had), and ansible should not fail on something so easily fixable.

 ### First version
[Here](https://github.com/toadjaune/ansible-elasticsearch/commit/c70fa8f8481a88ee2ecee1a24ba58fd8fce772fd?diff=split) is the fix I first came up with : 
* add a presence check with `sysd_stat_result.stat.exists`, to ensure not to test a non-existing dict key
* remove the second test, because it is useless : 
  * the [file module](https://docs.ansible.com/ansible/latest/modules/file_module.html) is idempotent, and won't change anything if it is not required, nor declare anything has changed unless it is the case.
  * this can actually correct an incorrect symlink, which is probably more fail-proof than the current code.

### Second version
The second version is the current PR, and is in my opinion way more elegant : we just get rid of all the test and the manual file suppression, and use the `force` option of the [file module](https://docs.ansible.com/ansible/latest/modules/file_module.html) instead.

The only functional difference with the first solution is that ansible will silently create the symlink even if the file it points to does not exist (instead of failing), which is not supposed to be possible (because this file is created earlier in the same task file), so it should be safe.

