### PR TITLE
add missing become: root

### DIFF
--- a/tasks/elasticsearch-config.yml
+++ b/tasks/elasticsearch-config.yml
@@ -93,13 +93,14 @@
     stat:
       path: "{{ sysd_script }}"
     register: sysd_stat_result
-  
+
   - name: Remove if it is a normal file
+    become: yes
     file:
       path: "{{ sysd_script }}"
       state: absent
     when: not sysd_stat_result.stat.islnk
-  
+
   - name: Create a symbolic link to the default systemd location to the first instance running on this host
     become: yes
     file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
   meta: flush_handlers
 
 - name: Make sure elasticsearch is started
+  become: yes
   service: name={{instance_init_script | basename}} state=started enabled=yes
   when: es_start_service
 

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -17,14 +17,16 @@
   when: (es_enable_xpack and "security" in es_xpack_features) and (es_version | version_compare('6.0.0', '>'))
   block:
   - name: create the keystore if it doesn't exist yet
+    become: yes
     command: >
      {{es_home}}/bin/elasticsearch-keystore create
     args:
       creates: "{{ conf_dir }}/elasticsearch.keystore"
     environment:
       ES_PATH_CONF: "{{ conf_dir }}"
-  
+
   - name: Check if bootstrap password is set
+    become: yes
     command: >
      {{es_home}}/bin/elasticsearch-keystore list
     register: list_keystore
@@ -33,6 +35,7 @@
       ES_PATH_CONF: "{{ conf_dir }}"
 
   - name: Create Bootstrap password for elastic user
+    become: yes
     shell: echo "{{es_api_basic_auth_password}}" | {{es_home}}/bin/elasticsearch-keystore add -x 'bootstrap.password'
     when:
       - es_api_basic_auth_username is defined and list_keystore is defined and es_api_basic_auth_username == 'elastic' and 'bootstrap.password' not in list_keystore.stdout_lines


### PR DESCRIPTION
I'm not sure if there are other become statements missing but these were the ones I needed initially ;)

Are these known? I saw at least one in [460](https://github.com/elastic/ansible-elasticsearch/pull/460) 