### PR TITLE
handle the nested response

### DIFF
--- a/tasks/snapshot-release.yml
+++ b/tasks/snapshot-release.yml
@@ -30,7 +30,7 @@
 
 - name: use the custom package url instead of the repository
   set_fact:
-    es_custom_package_url: "{{ snapshots.json[package_name]['url'] }}"
+    es_custom_package_url: "{{ snapshots.json['packages'][package_name]['url'] }}"
     es_use_repository: false
 
 - name: set snapshot urls for es_plugins when it is defined


### PR DESCRIPTION
The response from the search endpoint is now wrapped in a map with the
packages key.

I haven't updated DNS for the artifacts api, yet.  Aside from merging this after I update DNS, are there any other changes or steps needed here?