### PR TITLE
Set the role_name so that we can test from any directory

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 provisioner:
   name: ansible_playbook
   hosts: localhost
-  roles_path: ../
+  role_name: elastic.elasticsearch
   require_ansible_repo: false
   require_ansible_omnibus: false
   require_ansible_source: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ansible-elasticsearch
 test
+new test
 [![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+ansible-elasticsearch+master.svg)](https://devops-ci.elastic.co/job/elastic+ansible-elasticsearch+master/)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-elastic.elasticsearch-blue.svg)](https://galaxy.ansible.com/elastic/elasticsearch/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ansible-elasticsearch
+test
 [![Build Status](https://img.shields.io/jenkins/s/https/devops-ci.elastic.co/job/elastic+ansible-elasticsearch+master.svg)](https://devops-ci.elastic.co/job/elastic+ansible-elasticsearch+master/)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-elastic.elasticsearch-blue.svg)](https://galaxy.ansible.com/elastic/elasticsearch/)
 

--- a/test/integration/issue-test.yml
+++ b/test/integration/issue-test.yml
@@ -6,7 +6,7 @@
 - name: Simple Example
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/issue-test.yml
+++ b/test/integration/issue-test.yml
@@ -8,7 +8,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "security_node"
     es_xpack_license: "{{ lookup('file', '/tmp/license.json')  }}"

--- a/test/integration/multi.yml
+++ b/test/integration/multi.yml
@@ -3,7 +3,7 @@
 - name: Elasticsearch Multi test - master on 9200
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:
@@ -28,7 +28,7 @@
 - name: Elasticsearch Multi test - data on 9201
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/multi.yml
+++ b/test/integration/multi.yml
@@ -5,7 +5,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "master"
     es_data_dirs:
@@ -30,7 +30,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_enable_xpack: false
     es_scripts: true

--- a/test/integration/oss-to-xpack-upgrade.yml
+++ b/test/integration/oss-to-xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:
@@ -14,7 +14,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/oss-to-xpack-upgrade.yml
+++ b/test/integration/oss-to-xpack-upgrade.yml
@@ -4,7 +4,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_version: "{{ '6.2.4' if es_major_version == '6.x' else '5.6.9' }}" # This is set to an older version than the current default to force an upgrade
@@ -16,7 +16,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_enable_xpack: true

--- a/test/integration/oss-upgrade.yml
+++ b/test/integration/oss-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:
@@ -14,7 +14,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/oss-upgrade.yml
+++ b/test/integration/oss-upgrade.yml
@@ -4,7 +4,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_version: "{{ '6.2.4' if es_major_version == '6.x' else '5.6.9' }}" # This is set to an older version than the current default to force an upgrade
@@ -16,7 +16,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_enable_xpack: false

--- a/test/integration/oss.yml
+++ b/test/integration/oss.yml
@@ -4,7 +4,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_enable_xpack: false

--- a/test/integration/oss.yml
+++ b/test/integration/oss.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/xpack-upgrade.yml
+++ b/test/integration/xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Elasticsearch Xpack tests initial
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:
@@ -112,7 +112,7 @@
 - name: Elasticsearch Xpack modify
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:

--- a/test/integration/xpack-upgrade.yml
+++ b/test/integration/xpack-upgrade.yml
@@ -4,7 +4,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_instance_name: "node1"
     es_api_port: 9200
@@ -114,7 +114,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_api_port: 9200
     es_instance_name: "node1"

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -5,7 +5,7 @@
   post_tasks:
     - include: elasticsearch/test/integration/debug.yml
   roles:
-    - elasticsearch
+    - elastic.elasticsearch
   vars:
     es_api_port: 9200
     es_instance_name: "node1"

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -3,7 +3,7 @@
 - name: Elasticsearch Xpack tests - no security and manual download
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - include: roles/elastic.elasticsearch/test/integration/debug.yml
   roles:
     - elastic.elasticsearch
   vars:


### PR DESCRIPTION
The kitchen tests used to require that your current working directory
was set to 'elasticsearch'. Now it can be tested from any directory.