### PR TITLE
Change include to import_tasks and include_tasks when suitable to get rid of deprecation warnings

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -65,7 +65,7 @@
     ES_PATH_CONF: "/etc/elasticsearch"
 
 - name: Debian - Include versionlock
-  include: elasticsearch-Debian-version-lock.yml
+  include_tasks: elasticsearch-Debian-version-lock.yml
   when: es_version_lock
 
 - name: Debian - Download elasticsearch from url

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -10,7 +10,7 @@
   when: es_use_repository
 
 - name: RedHat - include versionlock
-  include: elasticsearch-RedHat-version-lock.yml
+  include_tasks: elasticsearch-RedHat-version-lock.yml
   when: es_version_lock
 
 - name: RedHat - Remove non oss package if the old elasticsearch package is installed

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -2,12 +2,12 @@
 
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
-  include: elasticsearch-optional-user.yml
+  include_tasks: elasticsearch-optional-user.yml
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-Debian.yml
+  include_tasks: elasticsearch-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-RedHat.yml
+  include_tasks: elasticsearch-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Include optional user and group creation.
-  when: (es_user_id is defined) and (es_group_id is defined)
   include_tasks: elasticsearch-optional-user.yml
+  when: (es_user_id is defined) and (es_group_id is defined)
 
 - name: Include specific Elasticsearch
   include_tasks: elasticsearch-Debian.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,12 +21,12 @@
       - java
 
 - name: include elasticsearch.yml
-  include: elasticsearch.yml
+  import_tasks: elasticsearch.yml
   tags:
       - install
 
 - name: include elasticsearch-config.yml
-  include: elasticsearch-config.yml
+  import_tasks: elasticsearch-config.yml
   tags:
       - config
 
@@ -44,7 +44,7 @@
 
   #We always execute xpack as we may need to remove features
 - name: include xpack/elasticsearch-xpack.yml
-  include: xpack/elasticsearch-xpack.yml
+  import_tasks: xpack/elasticsearch-xpack.yml
   tags:
       - xpack
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,21 +5,17 @@
       - always
 
 - name: set compatibility variables
-  include: compatibility-variables.yml
-  tags:
-      - always
+  import_tasks: compatibility-variables.yml
 
 - name: check-set-parameters
-  include: elasticsearch-parameters.yml
-  tags:
-      - always
+  import_tasks: elasticsearch-parameters.yml
 
 - name: use snapshot release
-  include: snapshot-release.yml
+  include_tasks: snapshot-release.yml
   when: es_use_snapshot_release
 
 - name: include java.yml
-  include: java.yml
+  include_tasks: java.yml
   when: es_java_install
   tags:
       - java
@@ -35,13 +31,13 @@
       - config
 
 - name: include elasticsearch-scripts.yml
-  include: elasticsearch-scripts.yml
+  include_tasks: elasticsearch-scripts.yml
   when: es_scripts
   tags:
       - scripts
 
 - name: include elasticsearch-plugins.yml
-  include: elasticsearch-plugins.yml
+  include_tasks: elasticsearch-plugins.yml
   when: es_plugins is defined or es_plugins_reinstall
   tags:
       - plugins
@@ -77,18 +73,18 @@
   when: manage_native_realm
 
 - name: activate-license
-  include: ./xpack/security/elasticsearch-xpack-activation.yml
+  include_tasks: ./xpack/security/elasticsearch-xpack-activation.yml
   when: es_start_service and es_enable_xpack and es_xpack_license is defined and es_xpack_license != ''
 
 #perform security actions here now elasticsearch is started
 - name: include xpack/security/elasticsearch-security-native.yml
-  include: ./xpack/security/elasticsearch-security-native.yml
+  include_tasks: ./xpack/security/elasticsearch-security-native.yml
   when: manage_native_realm
 
 #Templates done after restart - handled by flushing the handlers. e.g. suppose user removes security on a running node and doesn't specify es_api_basic_auth_username and es_api_basic_auth_password.  The templates will subsequently not be removed if we don't wait for the node to restart.
 #We also do after the native realm to ensure any changes are applied here first and its denf up.
 - name: include elasticsearch-template.yml
-  include: elasticsearch-template.yml
+  include_tasks: elasticsearch-template.yml
   when: es_templates
   tags:
       - templates

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -4,12 +4,12 @@
   set_fact: es_version_changed={{ ((elasticsearch_install_from_package is defined and (debian_elasticsearch_install_from_repo.changed or redhat_elasticsearch_install_from_repo.changed)) or (elasticsearch_install_from_package is defined and elasticsearch_install_from_package.changed)) }}
 
 - name: include elasticsearch-xpack-install.yml
-  include: elasticsearch-xpack-install.yml
+  include_tasks: elasticsearch-xpack-install.yml
   when: es_install_xpack
 
 #Security configuration
 - name: include security/elasticsearch-security.yml
-  include: security/elasticsearch-security.yml
+  import_tasks: security/elasticsearch-security.yml
 
 #Add any feature specific configuration here
 - name: Set Plugin Directory Permissions

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -46,7 +46,7 @@
 
 #-----------------------------FILE BASED REALM----------------------------------------
 
-- include: elasticsearch-security-file.yml
+- include_tasks: elasticsearch-security-file.yml
   when: (es_enable_xpack and "security" in es_xpack_features) and ((es_users is defined and es_users.file is defined) or (es_roles is defined and es_roles.file is defined))
 
 #-----------------------------ROLE MAPPING ----------------------------------------

--- a/test/integration/issue-test.yml
+++ b/test/integration/issue-test.yml
@@ -6,7 +6,7 @@
 - name: Simple Example
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/multi.yml
+++ b/test/integration/multi.yml
@@ -3,7 +3,7 @@
 - name: Elasticsearch Multi test - master on 9200
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -28,7 +28,7 @@
 - name: Elasticsearch Multi test - data on 9201
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/oss-to-xpack-upgrade.yml
+++ b/test/integration/oss-to-xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -14,7 +14,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/oss-upgrade.yml
+++ b/test/integration/oss-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -14,7 +14,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/oss.yml
+++ b/test/integration/oss.yml
@@ -2,7 +2,7 @@
 - name: Standard test for single node setup. Tests idempotence.
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/xpack-upgrade.yml
+++ b/test/integration/xpack-upgrade.yml
@@ -2,7 +2,7 @@
 - name: Elasticsearch Xpack tests initial
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:
@@ -112,7 +112,7 @@
 - name: Elasticsearch Xpack modify
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:

--- a/test/integration/xpack.yml
+++ b/test/integration/xpack.yml
@@ -3,7 +3,7 @@
 - name: Elasticsearch Xpack tests - no security and manual download
   hosts: localhost
   post_tasks:
-    - include: elasticsearch/test/integration/debug.yml
+    - import_tasks: elasticsearch/test/integration/debug.yml
   roles:
     - elasticsearch
   vars:


### PR DESCRIPTION
Ansible deprecated the include statement to import tasks and will remove it entirely in the future.

This leads to the following deprecation warning:
```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Both keywords still work with tagging, so there should be no downside to using the newer terms everywhere.

I changed the import/include statements in every task, including the tests.