### PR TITLE
add idempotence in check mode for plugins

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -30,6 +30,7 @@
     CONF_DIR: "{{ conf_dir }}"
     ES_PATH_CONF: "{{ conf_dir }}"
     ES_INCLUDE: "{{ instance_default_file }}"
+  check_mode: no
 
 #if es_plugins_reinstall is set to true we remove ALL plugins
 - name: set fact plugins_to_remove to install_plugins.stdout_lines


### PR DESCRIPTION

this line : 
check_mode: no
ensures that the variable installed_plugins is defined, and the next task can be run in check mode ('undefined variable' instead)