### PR TITLE
Fix the tested path.conf for 5.x

### DIFF
--- a/test/integration/helpers/serverspec/xpack_spec.rb
+++ b/test/integration/helpers/serverspec/xpack_spec.rb
@@ -5,9 +5,9 @@ shared_examples 'xpack::init' do |vars|
     it { should contain "node.name: localhost-#{vars['es_instance_name']}" }
     it { should contain 'cluster.name: elasticsearch' }
     if vars['es_major_version'] == '6.x'
-      it { should_not contain 'path.conf: /etc/elasticsearch/security_node' }
+      it { should_not contain "path.conf: /etc/elasticsearch/#{vars['es_instance_name']}" }
     else
-      it { should contain 'path.conf: /etc/elasticsearch/security_node' }
+      it { should contain "path.conf: /etc/elasticsearch/#{vars['es_instance_name']}" }
     end
     it { should contain "path.data: /var/lib/elasticsearch/localhost-#{vars['es_instance_name']}" }
     it { should contain "path.logs: /var/log/elasticsearch/localhost-#{vars['es_instance_name']}" }


### PR DESCRIPTION
This was previously passing because our CI configuration was actually
testing 6.x instead of 5.x. Luckily this is the only problem which
hadn't been caught since this was introduced.