### PR TITLE
Make the order of configs consistent for comparing

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,13 @@ An example of a two server deployment is shown below.  The first server holds th
     es_data_dirs: 
       - "/opt/elasticsearch"
     es_config:
+      cluster.name: "test-cluster"
       discovery.zen.ping.unicast.hosts: "elastic02:9300"
       http.port: 9200
       transport.tcp.port: 9300
       node.data: true
       node.master: false
       bootstrap.memory_lock: false
-      cluster.name: "test-cluster"
     es_scripts: false
     es_templates: false
     es_version_lock: false


### PR DESCRIPTION
When comparing `es_config` for master ([L198](https://github.com/elastic/ansible-elasticsearch/commit/571dde5ac2b57294d4becd5da6ca8553438ae6a2?diff=unified#diff-04c6e90faac2675aa89e2176d2eec7d8L198)) and data nodes([L220](https://github.com/elastic/ansible-elasticsearch/commit/571dde5ac2b57294d4becd5da6ca8553438ae6a2?diff=unified#diff-04c6e90faac2675aa89e2176d2eec7d8L220)), the order was different. This PR makes it consistent, hence it is easy to compare.

