### PR TITLE
backporting from master to work with ansible 2.7.4

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -53,7 +53,7 @@
   failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins }}"
-  when: "{{ item.plugin in plugins_to_install }}"
+  when: item.plugin in plugins_to_install
   notify: restart elasticsearch
   environment:
     CONF_DIR: "{{ conf_dir }}"

--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -50,7 +50,6 @@
 - name: Install elasticsearch plugins
   command: "{{es_home}}/bin/plugin install {{ item.plugin }} --batch --silent {% if item.proxy_host is defined and item.proxy_host != '' and item.proxy_port is defined and item.proxy_port != ''%} -DproxyHost={{ item.proxy_host }} -DproxyPort={{ item.proxy_port }} {% elif es_proxy_host is defined and es_proxy_host != '' %} -DproxyHost={{ es_proxy_host }} -DproxyPort={{ es_proxy_port }} {% endif %}"
   register: plugin_installed
-  failed_when: "'ERROR' in plugin_installed.stdout"
   changed_when: plugin_installed.rc == 0
   with_items: "{{ es_plugins }}"
   when: item.plugin in plugins_to_install


### PR DESCRIPTION
Preventing errors like:
```
TASK [elastic.elasticsearch : Install elasticsearch plugins] *******************
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ item.plugin in plugins_to_install }}
 
fatal: [default]: FAILED! => {"msg": "The conditional check ''ERROR' in plugin_installed.stdout' failed. The error was: error while evaluating conditional ('ERROR' in plugin_installed.stdout): Unable to look up a name or access an attribute in template string ({% if 'ERROR' in plugin_installed.stdout %} True {% else %} False {% endif %}).\nMake sure your variable name does not contain invalid characters like '-': argument of type 'StrictUndefined' is not iterable"}
    to retry, use: --limit @/tmp/ansible/site.retry
```