### PR TITLE
Allow switching between oss and standard packages

### DIFF
--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -14,6 +14,7 @@
     es_xpack_conf_subdir: ""
     es_repo_name: "{{ es_major_version }}"
     es_xpack_users_command: "elasticsearch-users"
+    es_other_package_name: "elasticsearch-oss"
 
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
@@ -33,6 +34,7 @@
   set_fact:
     es_repo_name: "{{ 'oss-' + es_major_version }}"
     es_package_name: "elasticsearch-oss"
+    es_other_package_name: "elasticsearch"
   when:
     - es_open_xpack
     - not es_enable_xpack

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -16,6 +16,7 @@
     es_xpack_users_command: "elasticsearch-users"
     es_other_package_name: "elasticsearch-oss"
     es_other_repo_name: "{{ 'oss-' + es_major_version }}"
+    es_other_apt_url: "deb https://artifacts.elastic.co/packages/{{ 'oss-' + es_major_version }}/apt stable main"
 
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
@@ -35,6 +36,7 @@
   set_fact:
     es_repo_name: "{{ 'oss-' + es_major_version }}"
     es_other_repo_name: "{{ es_major_version }}"
+    es_other_apt_url: "deb https://artifacts.elastic.co/packages/{{ es_major_version }}/apt stable main"
     es_package_name: "elasticsearch-oss"
     es_other_package_name: "elasticsearch"
   when:

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -15,6 +15,7 @@
     es_repo_name: "{{ es_major_version }}"
     es_xpack_users_command: "elasticsearch-users"
     es_other_package_name: "elasticsearch-oss"
+    es_other_repo_name: "{{ 'oss-' + es_major_version }}"
 
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
@@ -33,6 +34,7 @@
 - name: Use the oss repo and package if xpack is not being used
   set_fact:
     es_repo_name: "{{ 'oss-' + es_major_version }}"
+    es_other_repo_name: "{{ es_major_version }}"
     es_package_name: "elasticsearch-oss"
     es_other_package_name: "elasticsearch"
   when:

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -7,26 +7,8 @@
   set_fact: force_install=yes
   when: es_allow_downgrades
 
-- name: Debian - Install apt-transport-https to support https APT downloads
-  become: yes
-  apt: name=apt-transport-https state=present
-  when: es_use_repository
-
-- name: Debian - Add Elasticsearch repository key
-  become: yes
-  apt_key: url="{{ es_apt_key }}" state=present
-  when: es_use_repository and es_apt_key
-
-- name: Debian - Add elasticsearch repository
-  become: yes
-  apt_repository: repo={{ item.repo }} state={{ item.state}}
-  with_items:
-    - { repo: "{{ es_apt_url_old }}", state: "absent" }
-    - { repo: "{{ es_apt_url }}", state: "present" }
-  when: es_use_repository
-
-
 - name: Gracefully stop and remove elasticsearch package if switching between OSS and standard
+  become: yes
   block:
   - name: Check if the elasticsearch package is installed
     shell: "dpkg-query -W -f'${Status}' {{ es_other_package_name }}"
@@ -35,18 +17,41 @@
     changed_when: False
 
   - name: stop elasticsearch
-    become: yes
     service:
       name: '{{ instance_init_script | basename }}'
       state: stopped
     when: elasticsearch_package.stdout == 'install ok installed'
 
   - name: Debian - Remove elasticsearch package if we are switching to a different package type
-    become: yes
     apt:
       name: '{{ es_other_package_name }}'
       state: absent
     when: elasticsearch_package.stdout == 'install ok installed'
+
+
+- name: Install Elasticsearch repository
+  when: es_use_repository
+  become: yes
+  block:
+  - name: Debian - Install apt-transport-https to support https APT downloads
+    apt:
+      name: apt-transport-https
+      state: present
+
+  - name: Debian - Add Elasticsearch repository key
+    apt_key:
+      url: '{{ es_apt_key }}'
+      state: present
+    when: es_apt_key is defined
+
+  - name: Debian - Add elasticsearch repository
+    apt_repository:
+      repo: '{{ item.repo }}'
+      state: '{{ item.state }}'
+    with_items:
+      - { repo: "{{ es_apt_url_old }}", state: "absent" }
+      - { repo: "{{ es_apt_url }}", state: "present" }
+      - { repo: "{{ es_other_apt_url }}", state: "absent" }
 
 
 - name: Debian - Ensure elasticsearch is installed

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -26,12 +26,10 @@
   when: es_use_repository
 
 
-- name: Gracefully stop and remove elasticsearch if we are switching to the oss version
-  when:
-    - es_package_name == 'elasticsearch-oss'
+- name: Gracefully stop and remove elasticsearch package if switching between OSS and standard
   block:
   - name: Check if the elasticsearch package is installed
-    shell: dpkg-query -W -f'${Status}' elasticsearch
+    shell: "dpkg-query -W -f'${Status}' {{ es_other_package_name }}"
     register: elasticsearch_package
     failed_when: False
     changed_when: False
@@ -43,12 +41,13 @@
       state: stopped
     when: elasticsearch_package.stdout == 'install ok installed'
 
-  - name: Debian - Remove elasticsearch package if we are installing the oss package
+  - name: Debian - Remove elasticsearch package if we are switching to a different package type
     become: yes
     apt:
-      name: 'elasticsearch'
+      name: '{{ es_other_package_name }}'
       state: absent
     when: elasticsearch_package.stdout == 'install ok installed'
+
 
 - name: Debian - Ensure elasticsearch is installed
   become: yes

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -13,7 +13,16 @@
 
 - name: RedHat - add Elasticsearch repo
   become: yes
-  template: src=elasticsearch.repo dest=/etc/yum.repos.d/elasticsearch-{{ es_repo_name }}.repo
+  template:
+    src: 'elasticsearch.repo'
+    dest: '/etc/yum.repos.d/elasticsearch-{{ es_repo_name }}.repo'
+  when: es_use_repository
+
+- name: RedHat - remove unused Elasticsearch repo
+  become: yes
+  template:
+    src: 'elasticsearch.repo'
+    dest: '/etc/yum.repos.d/elasticsearch-{{ es_other_repo_name }}.repo'
   when: es_use_repository
 
 - name: RedHat - include versionlock

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -23,7 +23,7 @@
 - name: RedHat - Remove the other elasticsearch package if switching between OSS and standard
   become: yes
   yum:
-    name: es_other_package_name
+    name: '{{ es_other_package_name }}'
     state: 'absent'
 
 - name: RedHat - Install Elasticsearch

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -20,12 +20,11 @@
   include: elasticsearch-RedHat-version-lock.yml
   when: es_version_lock
 
-- name: RedHat - Remove non oss package if the old elasticsearch package is installed
+- name: RedHat - Remove the other elasticsearch package if switching between OSS and standard
   become: yes
   yum:
-    name: 'elasticsearch'
+    name: es_other_package_name
     state: 'absent'
-  when: es_package_name == 'elasticsearch-oss'
 
 - name: RedHat - Install Elasticsearch
   become: yes

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -20,9 +20,9 @@
 
 - name: RedHat - remove unused Elasticsearch repo
   become: yes
-  template:
-    src: 'elasticsearch.repo'
-    dest: '/etc/yum.repos.d/elasticsearch-{{ es_other_repo_name }}.repo'
+  file:
+    path: '/etc/yum.repos.d/elasticsearch-{{ es_other_repo_name }}.repo'
+    state: absent
   when: es_use_repository
 
 - name: RedHat - include versionlock


### PR DESCRIPTION
Before only going from the standard package to oss was supported. Now
this works properly in both directions.

Fixes: #520 