### PR TITLE
Fix package download URL

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -78,3 +78,5 @@
   when: not es_use_repository
   register: elasticsearch_install_from_package
   notify: restart elasticsearch
+  environment:
+    ES_PATH_CONF: "/etc/elasticsearch"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-es_package_url: "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch"
+es_package_url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch"
 es_conf_dir: "/etc/elasticsearch"
 sysd_script: "/usr/lib/systemd/system/elasticsearch.service"
 init_script: "/etc/init.d/elasticsearch"


### PR DESCRIPTION
The old URL yields a 404. This should work for both Debian and Red Hat.