### PR TITLE
Debian install: Only enforce version if flag is set

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -53,7 +53,7 @@
 - name: Debian - Ensure elasticsearch is installed
   become: yes
   apt:
-    name: '{{ es_package_name }}{% if es_version is defined and es_version != "" %}={{ es_version }}{% endif %}'
+    name: '{{ es_package_name }}{% if es_version_lock and es_version %}={{ es_version }}{% endif %}'
     state: present
     force: '{{ force_install }}'
     allow_unauthenticated: "{{ 'no' if es_apt_key else 'yes' }}"


### PR DESCRIPTION
`es_version` is defined in the defaults, therefore the condition always evaluates to `True` and the version is enforced.
I added the condition of `es_version_lock` and refactored the existing conditions into one (in Python, a boolean check on a string evaluates to false if it is either `None` or empty).

This task previously failed in our setup, because `es_version` defaults to `6.5.1` and `es_version_lock` is set to false. Regular system updates upgraded the package to `6.5.4`. In our case, apt fails with this message:

> '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"     install 'elasticsearch=6.5.1'' failed: E: Packages were downgraded and -y was used without --allow-d
owngrades.

I only changed the behaviour for Debian because I don't know if RetHat uses versioned package names in the repository that is used.
