### PR TITLE
Allow not installing Elasticsearch deb repository key

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -42,7 +42,7 @@
     apt_key:
       url: '{{ es_apt_key }}'
       state: present
-    when: es_apt_key is defined
+    when: es_apt_key | string
 
   - name: Debian - Add elasticsearch repository
     apt_repository:


### PR DESCRIPTION
If a variable is set in Ansible, there is no way to unset it ever again, i.e. setting `es_apt_key: null` or `es_apt_key: ~` do not work.

Since this value is set in `defaults/main.yml` we have to perform a boolean check on the string.