### PR TITLE
Execute java version check in check mode

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -18,6 +18,7 @@
   register: java_full_path
   failed_when: False
   changed_when: False
+  check_mode: no
   when: ansible_os_family == 'RedHat'
 
 - name: correct java version selected


### PR DESCRIPTION
This PR is related to this issue.
https://github.com/elastic/ansible-elasticsearch/issues/525

This problem is happened in --check mode, because in check mode ignored test for java_full_path and does not register it.
So this PR changed to execute in check mode and register java_full_path.
 