### PR TITLE
Use systemd's RequiresMountsFor

### DIFF
--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -3,6 +3,8 @@ Description=Elasticsearch-{{es_instance_name}}
 Documentation=http://www.elastic.co
 Wants=network-online.target
 After=network-online.target
+{# Directive 'WorkingDirectory' creates an implicit dependecy for {{es_home}}, so it can be omitted here #}
+RequiresMountsFor={{ data_dirs | array_to_str(separator=' ') }} {{log_dir}} {{pid_dir}} {{conf_dir}}
 
 [Service]
 Environment=ES_HOME={{es_home}}


### PR DESCRIPTION
User might be interested in separating ephemeral and persistent data.
Among others, this can be done by putting `data_dir` on another disk.

When doing that in cloud environments via [`cloud-init`](https://github.com/cloud-init/cloud-init) or [`waagent`](https://github.com/Azure/WALinuxAgent) you need to time the service start to _after_ the necessary devices are mounted, otherwise a low run-level can result in trying to start the service before all data/mounts is/are available.

This PR adds [systemd's `RequiresMountsFor`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiresMountsFor=) directive for the corresponding folders.