### PR TITLE
Template out the base of repo URLs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,9 @@ es_package_name: "elasticsearch"
 es_version_lock: false
 es_use_repository: true
 es_templates_fileglob: "files/templates/*.json"
-es_apt_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
-es_apt_url: "deb https://artifacts.elastic.co/packages/{{ es_repo_name }}/apt stable main"
+es_repo_base: "https://artifacts.elastic.co"
+es_apt_key: "{{ es_repo_base }}/GPG-KEY-elasticsearch"
+es_apt_url: "deb {{ es_repo_base }}/packages/{{ es_repo_name }}/apt stable main"
 es_apt_url_old: "deb http://packages.elastic.co/elasticsearch/{{ es_repo_name }}/debian stable main"
 es_start_service: true
 es_java_install: true

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -16,7 +16,7 @@
     es_xpack_users_command: "elasticsearch-users"
     es_other_package_name: "elasticsearch-oss"
     es_other_repo_name: "{{ 'oss-' + es_major_version }}"
-    es_other_apt_url: "deb https://artifacts.elastic.co/packages/{{ 'oss-' + es_major_version }}/apt stable main"
+    es_other_apt_url: "deb {{ es_repo_base }}/packages/{{ 'oss-' + es_major_version }}/apt stable main"
 
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
@@ -36,7 +36,7 @@
   set_fact:
     es_repo_name: "{{ 'oss-' + es_major_version }}"
     es_other_repo_name: "{{ es_major_version }}"
-    es_other_apt_url: "deb https://artifacts.elastic.co/packages/{{ es_major_version }}/apt stable main"
+    es_other_apt_url: "deb {{ es_repo_base }}/packages/{{ es_major_version }}/apt stable main"
     es_package_name: "elasticsearch-oss"
     es_other_package_name: "elasticsearch"
   when:

--- a/templates/elasticsearch.repo
+++ b/templates/elasticsearch.repo
@@ -1,8 +1,8 @@
 [elasticsearch-{{ es_repo_name }}]
 name=Elasticsearch repository for {{ es_repo_name }} packages
-baseurl=https://artifacts.elastic.co/packages/{{ es_repo_name }}/yum
+baseurl={{ es_repo_base }}/packages/{{ es_repo_name }}/yum
 gpgcheck=1
-gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+gpgkey={{ es_repo_base }}/GPG-KEY-elasticsearch
 enabled=1
 autorefresh=1
 type=rpm-md


### PR DESCRIPTION
Some popular artifact caches (e.g. Artifactory) do not provide `HTTP CONNECT` endpoints and thus aren't supported by `es_proxy_host` and `es_proxy_port`.  This patch templates out the scheme and authority components (i.e. "https://artifacts.elastic.co" ) of the apt and yum repo URLs to accommodate the use of such artifact caches.