### PR TITLE
Use dpkg_selections to lock elasticsearch version

### DIFF
--- a/tasks/elasticsearch-Debian-version-lock.yml
+++ b/tasks/elasticsearch-Debian-version-lock.yml
@@ -1,6 +1,6 @@
 ---
 - name: Debian - hold elasticsearch version
   become: yes
-  command: "apt-mark hold {{ es_package_name }}"
-  register: hold_elasticsearch_result
-  changed_when: "hold_elasticsearch_result.stdout != '{{ es_package_name }} was already set on hold.'"
+  dpkg_selections:
+    name: "{{ es_package_name }}"
+    selection: "hold"


### PR DESCRIPTION
Uses module dpkg_selections to hold elasticsearch version on debian.