### PR TITLE
Use sleep command in remplacement of pause

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
 
 # If playbook runs too fast, Native commands could fail as the Native Realm is not yet up
 - name: Wait 15 seconds for the Native Relm to come up
-  pause: seconds=15
+  command: sleep 15
   when: manage_native_realm
 
 - name: activate-license


### PR DESCRIPTION
Hi,
I did like to replace usage of pause module by sleep command.
Because pause module is not usable in free strategy it will raise an error:

ERROR! The 'pause' module bypasses the host loop, which is currently not supported in the free strategy and would instead execute for every host in the inventory list.

No side effect excepted.

>The error appears to have been in '<masked>elasticsearch/tasks/main.yml': line 75, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

>The offending line appears to be:

 >If playbook runs too fast, Native commands could fail as the Native Realm is not yet up
>- name: Wait 15 seconds for the Native Relm to come up
>  ^ here
