### PR TITLE
Fix typo in the .PHONY list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL:=/bin/bash -eux
 VERSION := 6.x
 PATTERN := xpack-ubuntu-1604
 
-.PHONY: converge cerify test login destroy list
+.PHONY: converge verify test login destroy list
 
 setup:
 	bundle install


### PR DESCRIPTION
Though it's a minor typo, `make verify` command would not work in a (presumably rare) case of file `verify` existing in the directory.