### PR TITLE
make playbook (tested for debians) compatible with the  mode

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -15,6 +15,7 @@
     register: elasticsearch_package
     failed_when: False
     changed_when: False
+    check_mode: no
 
   - name: stop elasticsearch
     service:

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -44,6 +44,7 @@
   register: open_jdk
   ignore_errors: yes
   changed_when: false
+  check_mode: no
 
 #https://github.com/docker-library/openjdk/issues/19 - ensures tests pass due to java 8 broken certs
 - name: refresh the java ca-certificates


### PR DESCRIPTION
Hey guys,

it was impossible to run the `--check` mode on top of the role.
(Please refer to the Ansible docs for details at: https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html)

The PR adds a micro tweak to properly `register` variables when in the check_mode.