### PR TITLE
Additional support for check mode on Debian

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -15,6 +15,7 @@
     register: elasticsearch_package
     failed_when: False
     changed_when: False
+    check_mode: no
 
   - name: stop elasticsearch
     service:

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -44,6 +44,7 @@
   register: open_jdk
   ignore_errors: yes
   changed_when: false
+  check_mode: no
 
 #https://github.com/docker-library/openjdk/issues/19 - ensures tests pass due to java 8 broken certs
 - name: refresh the java ca-certificates


### PR DESCRIPTION
This is related to #487, #377, #330, and and #527. The latest PR in #527 helped get check mode working but seemed only for the RedHat variant. This gets check mode working on an already installed Elasticsearch Debian node. The checks appear to just be listing commands so should be harmless in check mode.