### PR TITLE
Update readme to include versioned install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This role uses the json_query filter which [requires jmespath](https://github.co
 Create your Ansible playbook with your own tasks, and include the role elasticsearch. You will have to have this repository accessible within the context of playbook.
 
 ```sh
-ansible-galaxy install elastic.elasticsearch
+ansible-galaxy install elastic.elasticsearch,6.6.0
 ```
 
 Then create your playbook yaml adding the role elasticsearch. By default, the user is only required to specify a unique es_instance_name per role application.  This should be unique per node. 


### PR DESCRIPTION
In #538 it was discovered that recent versions of the ansible galaxy
command will fail if there aren't semver compatible releases in the
history.

The error says:

> Please contact the role author to resolve versioning conflicts, or
> specify an explicit role version to install.

Removing the old releases is not such a great idea so instead updating
the install command is the best option.

Fixes: #538