### PR TITLE
[ci] add JJBB job definitions

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,68 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: devops-ci
+
+##### JOB DEFAULTS
+
+- job:
+    project-type: matrix
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 100
+    parameters:
+    - string:
+        name: branch_specifier
+        default: master
+        description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
+          &lt;commitId&gt;, etc.)
+    properties:
+    - github:
+        url: https://github.com/elastic/ansible-elasticsearch/
+    - inject:
+        properties-content: HOME=$JENKINS_HOME
+    concurrent: true
+    node: master
+    scm:
+    - git:
+        name: origin
+        credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        reference-repo: /var/lib/jenkins/.git-references/ansible-elasticsearch.git
+        branches:
+        - ${branch_specifier}
+        url: git@github.com:elastic/ansible-elasticsearch.git
+        basedir: elasticsearch
+        wipe-workspace: 'False'
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: VERSION
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
+    - axis:
+        name: OS
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
+    - axis:
+        name: TEST_TYPE
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
+    vault:
+      url: https://secrets.elastic.co:8200
+      role_id: cff5d4e0-61bf-2497-645f-fcf019d10c13
+    wrappers:
+    - ansicolor
+    - timeout:
+        type: absolute
+        timeout: 360
+        fail: true
+    - timestamps
+    publishers:
+    - email:
+        recipients: infra-root+build@elastic.co

--- a/.ci/jobs/elastic+ansible-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+ansible-elasticsearch+master.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    name: elastic+ansible-elasticsearch+master
+    display-name: elastic / ansible-elasticsearch - master
+    description: Master branch testing with test kitchen
+    triggers:
+    - timed: H H(02-04) * * *
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        export ES_XPACK_LICENSE_FILE="$(pwd)/license.json"
+        echo "Getting xpack_license from secrets service"
+        set +x
+        VAULT_TOKEN=$( curl -s -X POST -H "Content-Type: application/json" -L -d "{\"role_id\":\"$VAULT_ROLE_ID\",\"secret_id\":\"$VAULT_SECRET_ID\"}" $VAULT_ADDR/v1/auth/approle/login | jq -r '.auth.client_token' )
+        curl -s -L -H "X-Vault-Token:$VAULT_TOKEN" $VAULT_ADDR/v1/secret/devops-ci/ansible-elasticsearch/xpack_license | jq -r '.data.value' > ${ES_XPACK_LICENSE_FILE}
+        set -x
+        echo "Finished getting xpack_license from secrets service"
+        make setup
+        make verify VERSION=$VERSION PATTERN=$TEST_TYPE-$OS

--- a/.ci/jobs/elastic+ansible-elasticsearch+pull-request.yml
+++ b/.ci/jobs/elastic+ansible-elasticsearch+pull-request.yml
@@ -1,0 +1,39 @@
+---
+- job:
+    name: elastic+ansible-elasticsearch+pull-request
+    display-name: elastic / ansible-elasticsearch - pull-request
+    description: Pull request testing with test kitchen
+    project-type: matrix
+    parameters: []
+    scm:
+    - git:
+        branches:
+        - $ghprbActualCommit
+        refspec: +refs/pull/*:refs/remotes/origin/pr/*
+    triggers:
+    - github-pull-request:
+        github-hooks: true
+        org-list:
+        - elastic
+        allow-whitelist-orgs-as-admins: true
+        cancel-builds-on-update: true
+        status-context: devops-ci
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -euo pipefail
+
+        export RBENV_VERSION='2.3.0'
+        export PATH="$HOME/.rbenv/bin:$PATH"
+        eval "$(rbenv init -)"
+        rbenv local $RBENV_VERSION
+
+        export ES_XPACK_LICENSE_FILE="$(pwd)/license.json"
+        echo "Getting xpack_license from secrets service"
+        set +x
+        VAULT_TOKEN=$( curl -s -X POST -H "Content-Type: application/json" -L -d "{\"role_id\":\"$VAULT_ROLE_ID\",\"secret_id\":\"$VAULT_SECRET_ID\"}" $VAULT_ADDR/v1/auth/approle/login | jq -r '.auth.client_token' )
+        curl -s -L -H "X-Vault-Token:$VAULT_TOKEN" $VAULT_ADDR/v1/secret/devops-ci/ansible-elasticsearch/xpack_license | jq -r '.data.value' > ${ES_XPACK_LICENSE_FILE}
+        set -x
+        echo "Finished getting xpack_license from secrets service"
+        make setup
+        make verify VERSION=$VERSION PATTERN=$TEST_TYPE-$OS


### PR DESCRIPTION
Add JJBB job definitions to the repo so they can be managed here.

Modified jobs so they will auto-generate the `inject-passwords` section
containing `VAULT_ROLE_ID`, `VAULT_SECRET_ID` and `VAULT_ADDR`.