### PR TITLE
Use full path to update-alternatives on RedHat like systems

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -13,7 +13,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Get the installed java path
-  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0 | head -1"
+  shell: "/usr/sbin/update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0 | head -1"
   become: yes
   register: java_full_path
   failed_when: False


### PR DESCRIPTION
Patch to use the full path to `update-alternatives` to mitigate a "Command not found" error on a minimal CentOS 7 server.