### PR TITLE
[test] fix debian-8 provisioning in kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -76,7 +76,7 @@ platforms:
       privileged: true
       provision_command:
         - echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
-        - echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.con
+        - echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
         - apt-get update && apt-get -y install -t jessie-backports openjdk-8-jre-headless
         - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml curl wget net-tools
         - sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,6 +75,8 @@ platforms:
       image: debian:8
       privileged: true
       provision_command:
+        - echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+        - echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.con
         - echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
         - apt-get update && apt-get -y install -t jessie-backports openjdk-8-jre-headless
         - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml curl wget net-tools

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -77,7 +77,6 @@ platforms:
       provision_command:
         - echo "deb http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
         - echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.con
-        - echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
         - apt-get update && apt-get -y install -t jessie-backports openjdk-8-jre-headless
         - apt-get update && apt-get -y install python python-dev python-pip build-essential libyaml-dev python-yaml curl wget net-tools
         - sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config


### PR DESCRIPTION
Jessie backport repos have been removed from debian mirrors and moved to archive mirrors (cf. https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html). We also need to disable validity checks as this repo is no more updated (https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository)