### PR TITLE
[gem] update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     builder (3.2.3)
     erubis (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.24)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
@@ -32,7 +32,7 @@ GEM
       net-ssh (>= 2.6.5)
     nori (2.6.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     test-kitchen (1.20.0)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)


### PR DESCRIPTION
This should fix vulnerability on ffi and rubyzip dependencies (cf. https://nvd.nist.gov/vuln/detail/CVE-2018-1000544 and https://nvd.nist.gov/vuln/detail/CVE-2018-1000201)