### PR TITLE
fix ''dict object has no attribute dict_keys" issue with python3

### DIFF
--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -22,8 +22,8 @@
     - es_api_basic_auth_password is not defined
 
 - name: set fact file_reserved_users
-  set_fact: file_reserved_users={{ es_users.file.keys() | intersect (reserved_xpack_users) }}
-  when: es_users is defined and es_users.file is defined and (es_users.file.keys() | length > 0) and (es_users.file.keys() | intersect (reserved_xpack_users) | length > 0)
+  set_fact: file_reserved_users={{ es_users.file.keys() | list | intersect (reserved_xpack_users) }}
+  when: es_users is defined and es_users.file is defined and (es_users.file.keys() | list | length > 0) and (es_users.file.keys() | list | intersect (reserved_xpack_users) | length > 0)
 
 - name: fail when changing users through file realm
   fail:

--- a/tasks/xpack/security/elasticsearch-security-file.yml
+++ b/tasks/xpack/security/elasticsearch-security-file.yml
@@ -1,6 +1,6 @@
 ---
 - name: set fact manage_file_users
-  set_fact: manage_file_users=es_users is defined and es_users.file is defined and es_users.file.keys() | length > 0
+  set_fact: manage_file_users=es_users is defined and es_users.file is defined and es_users.file | list | length > 0
 
 - name: Check if old users file exists
   stat:
@@ -35,7 +35,7 @@
   check_mode: no
 
 - name: set fact users_to_remove
-  set_fact: users_to_remove={{ current_file_users.stdout_lines | difference (es_users.file.keys()) }}
+  set_fact: users_to_remove={{ current_file_users.stdout_lines | difference (es_users.file.keys() | list) }}
   when: manage_file_users
 
 #Remove users
@@ -51,7 +51,7 @@
     ES_HOME: "{{es_home}}"
 
 - name: set fact users_to_add
-  set_fact: users_to_add={{ es_users.file.keys() | difference (current_file_users.stdout_lines) }}
+  set_fact: users_to_add={{ es_users.file.keys() | list | difference (current_file_users.stdout_lines) }}
   when: manage_file_users
 
 #Add users
@@ -72,7 +72,7 @@
   become: yes
   command: >
     {{es_home}}/bin/{{es_xpack_users_command}} passwd {{ item }} -p {{es_users.file[item].password}}
-  with_items: "{{ es_users.file.keys() | default([]) }}"
+  with_items: "{{ es_users.file.keys() | list }}"
   when: manage_file_users
   #Currently no easy way to figure out if the password has changed or to know what it currently is so we can skip.
   changed_when: False

--- a/tasks/xpack/security/elasticsearch-security-file.yml
+++ b/tasks/xpack/security/elasticsearch-security-file.yml
@@ -1,6 +1,6 @@
 ---
 - name: set fact manage_file_users
-  set_fact: manage_file_users=es_users is defined and es_users.file is defined and es_users.file | list | length > 0
+  set_fact: manage_file_users=es_users is defined and es_users.file is defined and es_users.file.keys() | list | length > 0
 
 - name: Check if old users file exists
   stat:

--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -83,7 +83,7 @@
   with_items: "{{ users_to_remove | default([]) }}"
 
 - name: set fact users_to_ignore
-  set_fact: users_to_ignore={{ native_users | list | intersect (reserved_users) }}
+  set_fact: users_to_ignore={{ native_users.keys() | list | intersect (reserved_users) }}
   when: manage_native_users
 
 - name: debug message
@@ -107,7 +107,7 @@
   with_items: "{{ users_to_ignore | default([]) }}"
 
 - name: set fact users_to_modify
-  set_fact: users_to_modify={{ native_users | list | difference (reserved_users) }}
+  set_fact: users_to_modify={{ native_users.keys() | list | difference (reserved_users) }}
   when: manage_native_users
 
 #Overwrite all other users NOT inc. those reserved

--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -7,14 +7,14 @@
 
 - name: set fact manage_native_users to true
   set_fact: manage_native_users=true
-  when: es_users is defined and es_users.native is defined and es_users.native.keys() | length > 0
+  when: es_users is defined and es_users.native is defined and es_users.native.keys() | list | length > 0
 
 - name: set fact manage_native_role to false
   set_fact: manage_native_roles=false
 
 - name: set fact manange_native_roles to true
   set_fact: manage_native_roles=true
-  when: es_roles is defined and es_roles.native is defined and es_roles.native.keys() | length > 0
+  when: es_roles is defined and es_roles.native is defined and es_roles.native.keys() | list | length > 0
 
 #If the node has just has security installed it maybe either stopped or started 1. if stopped, we need to start to load native realms 2. if started, we need to restart to load
 
@@ -37,7 +37,7 @@
 
 #Current users not inc. those reserved
 - name: set fact current_users equals user_list_response.json.keys not including reserved
-  set_fact: current_users={{ user_list_response.json.keys() | difference (reserved_users) }}
+  set_fact: current_users={{ user_list_response.json.keys() | list | difference (reserved_users) }}
   when: manage_native_users
 
 #We are changing the es_api_basic_auth_username password, so we need to do it first and update the param
@@ -67,7 +67,7 @@
 
 #Identify users that are present in ES but not declared and thus should be removed
 - name: set fact users_to_remove
-  set_fact: users_to_remove={{ current_users | difference ( native_users.keys() ) }}
+  set_fact: users_to_remove={{ current_users | difference ( native_users.keys() | list) }}
   when: manage_native_users
 
 #Delete all non required users NOT inc. reserved
@@ -83,7 +83,7 @@
   with_items: "{{ users_to_remove | default([]) }}"
 
 - name: set fact users_to_ignore
-  set_fact: users_to_ignore={{ native_users.keys() | intersect (reserved_users) }}
+  set_fact: users_to_ignore={{ native_users | list | intersect (reserved_users) }}
   when: manage_native_users
 
 - name: debug message
@@ -107,7 +107,7 @@
   with_items: "{{ users_to_ignore | default([]) }}"
 
 - name: set fact users_to_modify
-  set_fact: users_to_modify={{ native_users.keys() | difference (reserved_users) }}
+  set_fact: users_to_modify={{ native_users | list | difference (reserved_users) }}
   when: manage_native_users
 
 #Overwrite all other users NOT inc. those reserved
@@ -146,11 +146,11 @@
   when: manage_native_roles
 
 - name: set fact current roles
-  set_fact: current_roles={{ role_list_response.json.keys() | difference (reserved_roles) }}
+  set_fact: current_roles={{ role_list_response.json.keys() | list | difference (reserved_roles) }}
   when: manage_native_roles
 
 - name: set fact roles to ignore
-  set_fact: roles_to_ignore={{ es_roles.native.keys() | intersect (reserved_roles) | default([]) }}
+  set_fact: roles_to_ignore={{ es_roles.native.keys() | list | intersect (reserved_roles) | default([]) }}
   when: manage_native_roles
 
 - name: debug message
@@ -159,7 +159,7 @@
   when: manage_native_roles and roles_to_ignore | length > 0
 
 - name: set fact roles_to_remove
-  set_fact: roles_to_remove={{ current_roles | difference ( es_roles.native.keys()  ) }}
+  set_fact: roles_to_remove={{ current_roles | difference ( es_roles.native.keys() | list) }}
   when: manage_native_roles
 
 #Delete all non required roles NOT inc. reserved
@@ -175,7 +175,7 @@
   with_items: "{{roles_to_remove | default([]) }}"
 
 - name: set fact roles_to_modify
-  set_fact: roles_to_modify={{ es_roles.native.keys() | difference (reserved_roles) }}
+  set_fact: roles_to_modify={{ es_roles.native.keys() | list | difference (reserved_roles) }}
   when: manage_native_roles
 
 #Update other roles - NOT inc. reserved roles


### PR DESCRIPTION
In Python2, the dict.keys(), dict.values(), and dict.items() methods returns a list. Jinja2 returns that to Ansible via a string representation that Ansible can turn back into a list. In Python3, those methods return a dictionary view object.
resource: https://docs.ansible.com/ansible/2.4/playbooks_python_version.html#dictionary-views

Fix https://github.com/elastic/ansible-elasticsearch/issues/570