### PR TITLE
Add option for disable the addition of official repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ In addition to es_config, the following parameters allow the customization of th
 * ```es_max_open_files``` the maximum file descriptor number that can be opened by this process. Defaults to 65536.
 * ```es_max_threads``` the maximum number of threads the process can start. Defaults to 2048 (the minimum required by elasticsearch).
 * ```es_debian_startup_timeout``` how long Debian-family SysV init scripts wait for the service to start, in seconds. Defaults to 10 seconds.
-* ```es_use_repository``` Setting this to `false` will stop Ansible from using the official Elastic package repositories.
+* ```es_use_repository``` Setting this to `false` will stop Ansible from using the official Elastic package from any repository configured on the system.
+* ```es_add_repository``` Setting this to `false` will stop Ansible to add the official Elastic package repositories (if es_use_repository is true) if you want to use a repo already present.
 * ```es_custom_package_url``` the URL to the rpm or deb package for Ansible to install. When using this you will also need to set `es_use_repository: false` and make sure that the `es_version` matches the version being installed from your custom URL. E.g. `es_custom_package_url: https://downloads.example.com/elasticsearch.rpm`
 
 Earlier examples illustrate the installation of plugins using `es_plugins`.  For officially supported plugins no version or source delimiter is required. The plugin script will determine the appropriate plugin version based on the target Elasticsearch version.  For community based plugins include the full url.  This approach should NOT be used for the X-Pack plugin.  See X-Pack below for details here.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ es_enable_xpack: true
 es_package_name: "elasticsearch"
 es_version_lock: false
 es_use_repository: true
+es_add_repository: true
 es_templates_fileglob: "files/templates-{{ es_major_version }}/*.json"
 es_repo_base: "https://artifacts.elastic.co"
 es_apt_key: "{{ es_repo_base }}/GPG-KEY-elasticsearch"

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -43,12 +43,13 @@
     apt_key:
       url: '{{ es_apt_key }}'
       state: present
-    when: es_apt_key | string
+    when: es_add_repository and es_apt_key | string
 
   - name: Debian - Add elasticsearch repository
     apt_repository:
       repo: '{{ item.repo }}'
       state: '{{ item.state }}'
+    when: es_add_repository
     with_items:
       - { repo: "{{ es_apt_url_old }}", state: "absent" }
       - { repo: "{{ es_apt_url }}", state: "present" }

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -16,7 +16,7 @@
   template:
     src: 'elasticsearch.repo'
     dest: '/etc/yum.repos.d/elasticsearch-{{ es_repo_name }}.repo'
-  when: es_use_repository
+  when: es_use_repository and es_add_repository
 
 - name: RedHat - remove unused Elasticsearch repo
   become: yes


### PR DESCRIPTION
Sometimes, instances can't be access to public repository on internet. We must be able to use a private repository already deployed on instance.