### PR TITLE
Fixed deprecated ansible variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ An example of a three server deployment is shown below.  The first server holds 
 
 Parameters can additionally be assigned to hosts using the inventory file if desired.
 
-Make sure your hosts are defined in your ```inventory``` file with the appropriate ```ansible_ssh_host```,  ```ansible_ssh_user``` and ```ansible_ssh_private_key_file``` values.
+Make sure your hosts are defined in your ```inventory``` file with the appropriate ```ansible_host```,  ```ansible_user``` and ```ansible_ssh_private_key_file``` values.
 
 Then run it:
 


### PR DESCRIPTION
Ansible 2.0 has deprecated the “ssh” from `ansible_ssh_user`, `ansible_ssh_host`, and `ansible_ssh_port` to become `ansible_user`, `ansible_host`, and `ansible_port`.

See the [List of Behavioral Inventory Parameters](https://docs.ansible.com/ansible/2.3/intro_inventory.html#list-of-behavioral-inventory-parameters)