### PR TITLE
Add back in force_basic_auth for all http requests

### DIFF
--- a/tasks/elasticsearch-template.yml
+++ b/tasks/elasticsearch-template.yml
@@ -20,6 +20,7 @@
     status_code: 200
     user: "{{es_api_basic_auth_username | default(omit)}}"
     password: "{{es_api_basic_auth_password | default(omit)}}"
+    force_basic_auth: yes
     body_format: json
     body: "{{ lookup('file', item) }}"
   when: load_templates.changed and es_start_service

--- a/tasks/xpack/security/elasticsearch-xpack-activation.yml
+++ b/tasks/xpack/security/elasticsearch-xpack-activation.yml
@@ -8,6 +8,7 @@
     body_format: json
     body: "{{ es_xpack_license }}"
     return_content: yes
+    force_basic_auth: yes
   register: license_activated
   no_log: True
   failed_when: >


### PR DESCRIPTION
Related: #576
This is needed when using security for 6.x. All other http requests
still have this parameter added.