### PR TITLE
Remove always tag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,18 +6,12 @@
 
 - name: os-specific vars
   include_vars: "{{ansible_os_family}}.yml"
-  tags:
-      - always
 
 - name: set compatibility variables
   include: compatibility-variables.yml
-  tags:
-      - always
 
 - name: check-set-parameters
   include: elasticsearch-parameters.yml
-  tags:
-      - always
 
 - name: use snapshot release
   include: snapshot-release.yml


### PR DESCRIPTION
The usage of the always tag leads to errors if you run your playbook with a task that only gathers facts once, because always is executed even if the run is limited to another host.