### PR TITLE
Add SSL/TLS support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,3 +40,11 @@ es_debian_startup_timeout: 10
 
 # JVM custom parameters
 es_jvm_custom_parameters: ''
+
+# SSL/TLS parameters
+es_enable_http_ssl: false
+es_enable_transport_ssl: false
+es_ssl_key: ""
+es_ssl_certificate: ""
+es_ssl_certificate_authority: ""
+es_ssl_certificate_path: "/etc/elasticsearch/certs"

--- a/tasks/elasticsearch-ssl.yml
+++ b/tasks/elasticsearch-ssl.yml
@@ -1,0 +1,23 @@
+---
+- name: ensure certificate directory exists
+  file:
+    dest: "{{ es_ssl_certificate_path }}"
+    state: directory
+
+- name: Upload HTTP SSL/TLS certificates
+  copy:
+    src: "{{ item }}"
+    dest: "{{ es_ssl_certificate_path }}/{{ item | basename }}"
+  with_items:
+    - "{{ es_ssl_key }}"
+    - "{{ es_ssl_certificate }}"
+  when: es_enable_http_ssl|bool or es_enable_transport_ssl|bool
+
+- local_action: stat path="{{ role_path }}/files/{{ es_ssl_certificate_authority }}"
+  register: es_cafile
+
+- name: Upload SSL Certificate Authority
+  copy:
+    src: "{{ es_ssl_certificate_authority }}"
+    dest: "{{ es_ssl_certificate_path }}/{{ es_ssl_certificate_authority | basename }}"
+  when: es_cafile.stat.exists|bool and es_cafile.stat.isreg|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,9 @@
   tags:
       - xpack
 
+- name: include ssl.yml
+  include: elasticsearch-ssl.yml
+
 - name: flush handlers
   meta: flush_handlers
 

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -55,3 +55,22 @@ xpack.notification.email:
         password: {{ es_mail_config['pass'] }}
         {% endif %}
 {% endif %}
+
+{% if es_enable_http_ssl | bool %}
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.key: "{{ es_ssl_certificate_path }}/{{ es_ssl_key | basename }}"
+xpack.security.http.ssl.certificate: "{{ es_ssl_certificate_path }}/{{ es_ssl_certificate | basename }}"
+#xpack.security.http.ssl.client_authentication: optional
+{% if es_ssl_certificate_authority %}
+xpack.security.http.ssl.certificate_authorities: "{{ es_ssl_certificate_path }}/{{ es_ssl_certificate_authority | basename }}"
+{% endif %}
+{% else %}
+# xpack.security.http.ssl.enabled: false
+{% endif %}
+
+{% if es_enable_transport_ssl | bool %}
+xpack.security.transport.ssl.enabled: true
+#xpack.security.transport.ssl.verification_mode: certificate
+{% else %}
+# xpack.security.transport.ssl.enabled: false
+{% endif %}


### PR DESCRIPTION
This commit introduces SSL/TLS support for the elastic search transport
layer. It assumes certificates are generated externally, and only
handles uploading and configuring the server accordingly.