### PR TITLE
Removing package version hold when `es_version_hold: false`

### DIFF
--- a/tasks/elasticsearch-Debian-version-lock.yml
+++ b/tasks/elasticsearch-Debian-version-lock.yml
@@ -1,6 +1,0 @@
----
-- name: Debian - hold elasticsearch version
-  become: yes
-  dpkg_selections:
-    name: "{{ es_package_name }}"
-    selection: "hold"

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -17,6 +17,13 @@
     changed_when: False
     check_mode: no
 
+  - name: unhold elasticsearch package when switching to a different package type
+    become: yes
+    dpkg_selections:
+      name: "{{ es_other_package_name }}"
+      selection: "install"
+    when: elasticsearch_package.stdout == 'install ok installed'
+
   - name: stop elasticsearch
     service:
       name: 'elasticsearch'
@@ -59,6 +66,20 @@
   when: (es_user_id is defined) and (es_group_id is defined)
   include: elasticsearch-optional-user.yml
 
+- name: Debian - Get installed elasticsearch version
+  command: dpkg-query --showformat='${Version}' --show {{ es_package_name }}
+  register: installed_es_version
+  failed_when: False
+  changed_when: False
+  check_mode: no
+
+- name: Debian - unhold elasticsearch version
+  become: yes
+  dpkg_selections:
+    name: "{{ es_package_name }}"
+    selection: "install"
+  when: not es_version_lock or (installed_es_version.stdout and installed_es_version.stdout != es_version)
+
 - name: Debian - Ensure elasticsearch is installed
   become: yes
   apt:
@@ -73,8 +94,11 @@
   environment:
     ES_PATH_CONF: "/etc/elasticsearch"
 
-- name: Debian - Include versionlock
-  include: elasticsearch-Debian-version-lock.yml
+- name: Debian - hold elasticsearch version
+  become: yes
+  dpkg_selections:
+    name: "{{ es_package_name }}"
+    selection: "hold"
   when: es_version_lock
 
 - name: Debian - Download elasticsearch from url

--- a/tasks/elasticsearch-RedHat-version-lock.yml
+++ b/tasks/elasticsearch-RedHat-version-lock.yml
@@ -2,6 +2,35 @@
 - name: RedHat - install yum-version-lock
   become: yes
   yum: name=yum-plugin-versionlock state=present update_cache=yes
+
+- name: RedHat - check if requested elasticsearch version lock exists
+  become: yes
+  shell: yum versionlock list | grep -c {{es_package_name}}-{{es_version}}
+  register: es_requested_version_locked
+  args:
+    warn: false
+  failed_when: False
+  changed_when: False
+
 - name: RedHat - lock elasticsearch version
   become: yes
-  shell: yum versionlock delete 0:elasticsearch* ; yum versionlock add {{ es_package_name }}{% if es_version is defined and es_version != "" %}-{{ es_version }}{% endif %}
+  shell: yum versionlock delete 0:elasticsearch* ; yum versionlock add {{ es_package_name }}-{{ es_version }}
+  args:
+    warn: false
+  when: es_version_lock and es_requested_version_locked.stdout|int == 0
+
+- name: RedHat - check if any elasticsearch version lock exists
+  become: yes
+  shell: yum versionlock list | grep -c elasticsearch
+  register: es_version_locked
+  args:
+    warn: false
+  failed_when: False
+  changed_when: False
+
+- name: RedHat - unlock elasticsearch version
+  become: yes
+  shell: yum versionlock delete 0:elasticsearch*
+  args:
+    warn: false
+  when: not es_version_lock and es_version_locked.stdout|int > 0

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -27,7 +27,6 @@
 
 - name: RedHat - include versionlock
   include: elasticsearch-RedHat-version-lock.yml
-  when: es_version_lock
 
 - name: RedHat - Remove the other elasticsearch package if switching between OSS and standard
   become: yes


### PR DESCRIPTION
Fix for https://github.com/elastic/ansible-elasticsearch/issues/499