### PR TITLE
Added variable for forcing use of non-oss repo when x-pack security is disabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ es_package_name: "elasticsearch"
 es_version_lock: false
 es_use_repository: true
 es_add_repository: true
+es_force_non_oss_repo: false
 es_templates_fileglob: "files/templates-{{ es_major_version }}/*.json"
 es_repo_base: "https://artifacts.elastic.co"
 es_apt_key: "{{ es_repo_base }}/GPG-KEY-elasticsearch"

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -43,3 +43,4 @@
   when:
     - es_open_xpack
     - not es_enable_xpack
+    - not es_force_non_oss_repo


### PR DESCRIPTION
Proposed fix to https://github.com/elastic/ansible-elasticsearch/issues/602