### PR TITLE
Add probot config to manage stale issues/pr

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,3 @@
-<!
 <!--
 
 ** Please read the guidelines below. **

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+---
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an stale issue is closed
+daysUntilClose: 30
+
+# Label to use when marking an issue as stale
+staleLabel: triage/stale
+
+issues:
+  # Comment to post when marking an issue as stale.
+  markComment: |-
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Comment to post when closing a stale issue.
+  closeComment: |-
+    This issue has been automatically closed because it has not had recent
+    activity since being marked as stale.
+
+pulls:
+  # Comment to post when marking a PR as stale.
+  markComment: |-
+    This PR has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+    To track this PR (even if closed), please open a corresponding issue if one does not already exist.
+  # Comment to post when closing a stale PR.
+  closeComment: |-
+    This PR has been automatically closed because it has not had recent
+    activity since being marked as stale.
+    Please reopen when work resumes.


### PR DESCRIPTION
This PR add [Probot](https://probot.github.io/) configuration to manage stale issues/PR:

- Issues / PR will be marked as stale (with a `triage/stale` label) after 90 days without any activity.
- Stale issues / PR will be closed automatically after 30 days without any activity.