### PR TITLE
[doc] describe how to select a different elasticsearch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ The simplest configuration therefore consists of:
   hosts: localhost
   roles:
     - role: elastic.elasticsearch
+  vars:
+    es_version: 7.1.1
 ```
 
-The above installs a single node 'node1' on the hosts 'localhost'.
+The above installs Elasticsearch 7.1.1 in a single node 'node1' on the hosts 'localhost'.
+
+**Note**:
+Elasticsearch default version is described in [`es_version`](defaults/main.yml#L2). You can override this variable in your playbook to install another version.
+While we are testing this role only with one 7.x and one 6.x version (respectively [7.1.1](defaults/main.yml#L2) and [6.8.0](.kitchen.yml#L22) at the time of writing), this role should work with others version also in most cases.
 
 This role also uses [Ansible tags](http://docs.ansible.com/ansible/playbooks_tags.html). Run your playbook with the `--list-tasks` flag for more information.
 


### PR DESCRIPTION
We regularly receive requests about releasing new versions of this Ansible role to allow deployment of new Elasticsearch versions.

While we should definitively improve our release process to follow Elasticsearch release, we need also to clarify the fact that in most cases, deploying a different version can  be done easily by overriding [`es_version`](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2) variable.