### PR TITLE
Fixes AttributeError

### DIFF
--- a/filter_plugins/custom.py
+++ b/filter_plugins/custom.py
@@ -23,7 +23,7 @@ def array_to_str(values=[],separator=','):
 
 def extract_role_users(users={},exclude_users=[]):
     role_users=[]
-    for user,details in users.iteritems():
+    for user,details in users.items():
         if user not in exclude_users and "roles" in details:
             for role in details["roles"]:
                 role_users.append(role+":"+user)


### PR DESCRIPTION
This fixes the following error:

```
TASK [Set fact users_roles]

The full traceback is:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/ansible/executor/task_executor.py", line 144, in run
    res = self._execute()
  File "/usr/local/lib/python3.7/site-packages/ansible/executor/task_executor.py", line 576, in _execute
    self._task.post_validate(templar=templar)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/task.py", line 268, in post_validate
    super(Task, self).post_validate(templar)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/base.py", line 382, in post_validate
    value = templar.template(getattr(self, name))
  File "/usr/local/lib/python3.7/site-packages/ansible/template/__init__.py", line 584, in template
    disable_lookups=disable_lookups,
  File "/usr/local/lib/python3.7/site-packages/ansible/template/__init__.py", line 539, in template
    disable_lookups=disable_lookups,
  File "/usr/local/lib/python3.7/site-packages/ansible/template/__init__.py", line 804, in do_template
    res = j2_concat(rf)
  File "<template>", line 9, in root
  File "filter_plugins/custom.py", line 27, in extract_role_users
    for user,details in users.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'

fatal: [foo.cloudapp.azure.com]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

When using Ansible 2.8.0 with Python 3.7.4. As per this [post](https://stackoverflow.com/a/30418498/55075), `iteritems()` has been removed from Python 3. It seems other parts of code is using `items()` instead.