### PR TITLE
Allow user to specify the http schema.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,11 +35,10 @@ es_allow_downgrades: false
 es_xpack_features: []
 #These are used for internal operations performed by ansible.
 #They do not affect the current configuration
+es_api_scheme: http
 es_api_host: "localhost"
 es_api_port: 9200
 es_debian_startup_timeout: 10
 
 # JVM custom parameters
 es_jvm_custom_parameters: ''
-
-es_http_scheme: http

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,5 @@ es_debian_startup_timeout: 10
 
 # JVM custom parameters
 es_jvm_custom_parameters: ''
+
+es_http_scheme: http

--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -21,7 +21,7 @@
 #List current users
 - name: List Native Users
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user"
     method: GET
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
@@ -51,7 +51,7 @@
 
 - name: Update API User Password
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{es_api_basic_auth_username}}/_password"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{es_api_basic_auth_username}}/_password"
     method: POST
     body_format: json
     body: "{ \"password\":\"{{native_users[es_api_basic_auth_username].password}}\" }"
@@ -73,7 +73,7 @@
 #Delete all non required users NOT inc. reserved
 - name: Delete Native Users
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -94,7 +94,7 @@
 #Update password on all reserved users
 - name: Update Reserved User Passwords
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}/_password"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}/_password"
     method: POST
     body_format: json
     body: "{ \"password\":\"{{native_users[item].password}}\" }"
@@ -113,7 +113,7 @@
 #Overwrite all other users NOT inc. those reserved
 - name: Update Non-Reserved Native User Details
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
     method: POST
     body_format: json
     body: "{{ native_users[item] | to_json }}"
@@ -131,7 +131,7 @@
 #List current roles not. inc those reserved
 - name: List Native Roles
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role"
     method: GET
     body_format: json
     user: "{{es_api_basic_auth_username}}"
@@ -166,7 +166,7 @@
 #Delete all non required roles NOT inc. reserved
 - name: Delete Native Roles
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -182,7 +182,7 @@
 #Update other roles - NOT inc. reserved roles
 - name: Update Native Roles
   uri:
-    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
+    url: "{{ es_api_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
     method: POST
     body_format: json
     body: "{{ es_roles.native[item] | to_json}}"

--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -21,7 +21,7 @@
 #List current users
 - name: List Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user"
     method: GET
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
@@ -51,7 +51,7 @@
 
 - name: Update API User Password
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{es_api_basic_auth_username}}/_password
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{es_api_basic_auth_username}}/_password"
     method: POST
     body_format: json
     body: "{ \"password\":\"{{native_users[es_api_basic_auth_username].password}}\" }"
@@ -73,7 +73,7 @@
 #Delete all non required users NOT inc. reserved
 - name: Delete Native Users
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -94,7 +94,7 @@
 #Update password on all reserved users
 - name: Update Reserved User Passwords
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}/_password
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}/_password"
     method: POST
     body_format: json
     body: "{ \"password\":\"{{native_users[item].password}}\" }"
@@ -113,7 +113,7 @@
 #Overwrite all other users NOT inc. those reserved
 - name: Update Non-Reserved Native User Details
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/user/{{item}}"
     method: POST
     body_format: json
     body: "{{ native_users[item] | to_json }}"
@@ -121,8 +121,9 @@
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes
+    timeout: 60
   when: manage_native_users
-  no_log: True
+  no_log: False
   with_items: "{{ users_to_modify | default([]) }}"
 
 ## ROLE CHANGES
@@ -130,7 +131,7 @@
 #List current roles not. inc those reserved
 - name: List Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role"
     method: GET
     body_format: json
     user: "{{es_api_basic_auth_username}}"
@@ -165,7 +166,7 @@
 #Delete all non required roles NOT inc. reserved
 - name: Delete Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
     method: DELETE
     status_code: 200
     user: "{{es_api_basic_auth_username}}"
@@ -181,7 +182,7 @@
 #Update other roles - NOT inc. reserved roles
 - name: Update Native Roles
   uri:
-    url: http://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}
+    url: "{{ es_http_scheme }}://{{es_api_host}}:{{es_api_port}}/_xpack/security/role/{{item}}"
     method: POST
     body_format: json
     body: "{{ es_roles.native[item] | to_json}}"


### PR DESCRIPTION
This is a really simple fix that would allow us to use this module with a https elastic search. There is a PR #620 that would also allow for this to be done but this is a much smaller fix that can hopefully be merged faster. 

To avoid issues with that PR once this one is merged (or discarded) I've used the same variables as those defined by #620 