### PR TITLE
disable ubuntu-1404 tests

### DIFF
--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -2,7 +2,6 @@ VERSION:
   - 7.x
   - 6.x
 OS:
-  - ubuntu-1404
   - ubuntu-1604
   - ubuntu-1804
   - debian-8


### PR DESCRIPTION
Tests on Ubuntu 14.04 are currently broken because of https://github.com/test-kitchen/kitchen-docker/issues/353