### PR TITLE
Trigger ca-certificates-java post installation script only when it's installed

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -39,16 +39,13 @@
   apt: name={{ java }} state={{java_state}}
   when: ansible_os_family == 'Debian'
 
-- name: register open_jdk version
-  shell: java -version 2>&1 | grep OpenJDK
-  register: open_jdk
-  ignore_errors: yes
-  changed_when: false
-  check_mode: no
+- name: Ubuntu - Get installed packages
+  package_facts:
+  when: ansible_distribution == 'Ubuntu'
 
 #https://github.com/docker-library/openjdk/issues/19 - ensures tests pass due to java 8 broken certs
 - name: refresh the java ca-certificates
   become: yes
   command: /var/lib/dpkg/info/ca-certificates-java.postinst configure
-  when: ansible_distribution == 'Ubuntu' and open_jdk.rc == 0
+  when: ansible_distribution == 'Ubuntu' and 'ca-certificates-java' in ansible_facts.packages
   changed_when: false


### PR DESCRIPTION
This role fails to execute on a Ubuntu machine with Amazon JDK Corretto because it's assuming `ca-certificates-java` is installed while this isn't the case. 

Amazon JDK Corretto is based on OpenJDK, thus it should be compatible with OpenJDK.

Installing `ca-certificates-java` isn't a workaround as it would install openjdk also (since amazon corretto doesn't provide `java8-runtime-headless`).