### PR TITLE
heap.dump.path is set as mandatory variable. Setting it to optional i…

### DIFF
--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -110,7 +110,9 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=${heap.dump.path}
+{% if heap.dump.path is defined %} 
+-XX:HeapDumpPath=${heap.dump.path} 
+{% endif %}
 
 # specify an alternative path for JVM fatal error logs
 -XX:ErrorFile={{ es_log_dir }}/hs_err_pid%p.log


### PR DESCRIPTION
heap.dump.path is set as mandatory variable. 
Currently, if heap.dump.path is not defined then after deployment in linux it appears as "-XX:HeapDumpPath=${heap.dump.path}" in elastic+ process

Setting it to optional if defined.