### PR TITLE
Introduce es_java_home variable to allow setting JAVA_HOME 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ es_api_sleep: 15
 es_debian_startup_timeout: 10
 
 # JVM custom parameters
+es_java_home: ''
 es_jvm_custom_parameters: ''
 
 # SSL/TLS parameters

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -6,7 +6,11 @@
 ES_HOME={{es_home}}
 
 # Elasticsearch Java path
+{% if es_java_home | length > 0 %}
+JAVA_HOME={{ es_java_home }}
+{% else %}
 #JAVA_HOME=
+{% endif %}
 
 # Elasticsearch configuration directory
 ES_PATH_CONF={{ es_conf_dir }}


### PR DESCRIPTION
This PR introduces a variable called `es_java_home`, which defaults to an empty string.  If set to a non-empty string, that string is used to set the JAVA_HOME environment variable in the default config file (via the `templates/elasticsearch.j2` template).

If `es_java_home` is not changed from its default, the file generated from the template is unchanged.  That is to say, this change should be entirely backwards-compatible.