### PR TITLE
[meta] export VERSION variable to make subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default: build
 
 SHELL:=/bin/bash -eux
-VERSION := 7.x
+export VERSION := 7.x
 PATTERN := xpack-ubuntu-1604
 
 .PHONY: converge verify test login destroy list


### PR DESCRIPTION
This fix an issue where `VERSION` was exported to kitchen tests only if it was set as environment variable in the shell calling `make`

Fixes #633 (related to https://github.com/elastic/ansible-elasticsearch/pull/620#discussion_r341119867).