### PR TITLE
Removed port from initial_master_nodes setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ An example of a three server deployment is shown below.  The first server holds 
     es_heap_size: "1g"
     es_config:
       cluster.name: "test-cluster"
-      cluster.initial_master_nodes: "elastic02:9300"
+      cluster.initial_master_nodes: "elastic02"
       discovery.seed_hosts: "elastic02:9300"
       http.port: 9200
       node.data: false
@@ -252,7 +252,7 @@ An example of a three server deployment is shown below.  The first server holds 
       - "/opt/elasticsearch"
     es_config:
       cluster.name: "test-cluster"
-      cluster.initial_master_nodes: "elastic02:9300"
+      cluster.initial_master_nodes: "elastic02"
       discovery.seed_hosts: "elastic02:9300"
       http.port: 9200
       node.data: true


### PR DESCRIPTION
Nodes won't be able to join the cluster if the port is specified in `initial_master_nodes`.  

The `cluster.initial_master_nodes` setting is used to determine the identities of the subset of master-eligible nodes that participate in the bootstrapping process.

See ES documentation [here](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-discovery-bootstrap-cluster.html). 



