### PR TITLE
[meta] bump minimal ansible version to 2.5.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Elasticsearch for Linux
   company: "Elastic.co"
   license: "license (Apache)"
-  min_ansible_version: 2.4.2
+  min_ansible_version: 2.5.0
   platforms:
   - name: EL
     versions:


### PR DESCRIPTION
This is required following 20d2a8f as `version` replace `version_compare` in Ansible 2.5.