### PR TITLE
Update jvm options with default values for 7.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ An example of a three server deployment is shown below.  The first server holds 
     es_heap_size: "1g"
     es_config:
       cluster.name: "test-cluster"
-      cluster.initial_master_nodes: "elastic02:9300"
+      cluster.initial_master_nodes: "elastic02"
       discovery.seed_hosts: "elastic02:9300"
       http.port: 9200
       node.data: false
@@ -252,7 +252,7 @@ An example of a three server deployment is shown below.  The first server holds 
       - "/opt/elasticsearch"
     es_config:
       cluster.name: "test-cluster"
-      cluster.initial_master_nodes: "elastic02:9300"
+      cluster.initial_master_nodes: "elastic02"
       discovery.seed_hosts: "elastic02:9300"
       http.port: 9200
       node.data: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ es_debian_startup_timeout: 10
 # JVM custom parameters
 es_java_home: ''
 es_jvm_custom_parameters: ''
+es_heap_dump_path: "/var/lib/elasticsearch"
 
 # SSL/TLS parameters
 es_enable_auto_ssl_configuration: true

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -37,12 +37,19 @@
 ################################################################
 
 ## GC configuration
+{% if es_version is version('7.6.0', '<') %}
 -XX:+UseConcMarkSweepGC
 -XX:CMSInitiatingOccupancyFraction=75
 -XX:+UseCMSInitiatingOccupancyOnly
+{% else %}
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+{% endif %}
 
 ## G1GC Configuration
-# NOTE: G1GC is only supported on JDK version 10 or later.
+# NOTE: G1 GC is only supported on JDK version 10 or later
+{% if es_version is version('7.6.0', '<') %}
 # To use G1GC uncomment the lines below.
 # 10-:-XX:-UseConcMarkSweepGC
 # 10-:-XX:-UseCMSInitiatingOccupancyOnly
@@ -52,6 +59,15 @@
 {% else %}
 # 10-:-XX:G1ReservePercent=25
 # 10-:-XX:InitiatingHeapOccupancyPercent=30
+{% endif %}
+{% else %}
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
 {% endif %}
 
 {% if es_version is version('7.5.0', '<') %}
@@ -100,6 +116,7 @@
 -Dlog4j2.disable.jmx=true
 {% endif %}
 
+## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
 
 ## heap dumps

--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -127,7 +127,7 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=${heap.dump.path}
+-XX:HeapDumpPath={{ es_heap_dump_path }}
 
 # specify an alternative path for JVM fatal error logs
 -XX:ErrorFile={{ es_log_dir }}/hs_err_pid%p.log


### PR DESCRIPTION
- Update JVM options to include changes made in elastic/elasticsearch#49123
- Add a new variable to allow overriding heap dump path (replace #668)