### PR TITLE
Update elasticsearch-security-file.yml

### DIFF
--- a/tasks/xpack/security/elasticsearch-security-file.yml
+++ b/tasks/xpack/security/elasticsearch-security-file.yml
@@ -6,12 +6,14 @@
 
 # Users migration from elasticsearch < 6.3 versions
 - name: Check if old users file exists
+  become: yes
   stat:
     path: '{{ es_conf_dir }}/x-pack/users'
   register: old_users_file
   check_mode: no
 
 - name: Copy the old users file from the old deprecated location
+  become: yes
   copy:
     remote_src: yes
     force: no # only copy it if the new path doesn't exist yet


### PR DESCRIPTION
Without become option stat operation for old users file will work only if user is in elasticsearch group, but copying of old file will fail because user have no write access in elasticsearch config dir.