### PR TITLE
[meta] add slack notifications to CI jobs

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -62,6 +62,4 @@
         timeout: 360
         fail: true
     - timestamps
-    publishers:
-    - email:
-        recipients: infra-root+build@elastic.co
+

--- a/.ci/jobs/elastic+ansible-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+ansible-elasticsearch+master.yml
@@ -24,3 +24,10 @@
         echo "Finished getting xpack_license from secrets service"
         make setup
         make verify VERSION=$VERSION PATTERN=$TEST_TYPE-$OS
+    publishers:
+    - slack:
+        notify-back-to-normal: True
+        notify-every-failure: True
+        room: infra-release-notify
+        team-domain: elastic
+        auth-token-id: release-slack-integration-token


### PR DESCRIPTION
This PR add Slack notifications to Elastic Release team Slack channel for [elastic+ansible-elasticsearch+master](https://devops-ci.elastic.co/job/elastic+ansible-elasticsearch+master/) test job.