### PR TITLE
add ansible var for ES_TMPDIR env var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ es_config_jvm: "jvm.options.j2"
 #Need to provide default directories
 es_conf_dir: "/etc/elasticsearch"
 es_pid_dir: "/var/run/elasticsearch"
+es_tmp_dir: "/tmp"
 es_data_dirs:
   - "/var/lib/elasticsearch"
 es_log_dir: "/var/log/elasticsearch"

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -5,6 +5,9 @@
 # Elasticsearch home directory
 ES_HOME={{es_home}}
 
+# Elasticsearch temp directory
+ES_TMPDIR={{ es_tmp_dir }}
+
 # Elasticsearch Java path
 {% if es_java_home | length > 0 %}
 JAVA_HOME={{ es_java_home }}


### PR DESCRIPTION
Elasticsearch requires its temp directory to be mounted as executable (see [executable-jna-tmpdir](https://www.elastic.co/guide/en/elasticsearch/reference/current/executable-jna-tmpdir.html)).  However, the CIS guidelines (e.g., [CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v2.1.1](http://www.itsecure.hu/library/image/CIS_Red_Hat_Enterprise_Linux_7_Benchmark_v2.1.1.pdf), 1.1.5) recommend mounting /tmp with noexec.  Therefore, users of this ansible role may have reason to set elasticsearch's temp dir to a non-default location.

(The elasticsearch environment variable ES_TMPDIR gets set to /tmp by default.  This PR preserves this default behavior.)