### PR TITLE
Use run_once for api related tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,15 +89,18 @@
 - name: activate-license
   include: ./xpack/security/elasticsearch-xpack-activation.yml
   when: es_start_service and not oss_version and es_xpack_license is defined and es_xpack_license != ''
+  run_once: True
 
 - name: activate-trial
   include: ./xpack/security/elasticsearch-xpack-trial-activation.yml
   when: es_start_service and not oss_version and es_xpack_trial
+  run_once: True
 
 #perform security actions here now elasticsearch is started
 - name: include xpack/security/elasticsearch-security-native.yml
   include: ./xpack/security/elasticsearch-security-native.yml
   when: manage_native_realm | bool
+  run_once: True
 
 #Templates done after restart - handled by flushing the handlers. e.g. suppose user removes security on a running node and doesn't specify es_api_basic_auth_username and es_api_basic_auth_password.  The templates will subsequently not be removed if we don't wait for the node to restart.
 #We also do after the native realm to ensure any changes are applied here first and its denf up.


### PR DESCRIPTION
I am proposing a fix for issue #710. By specifying run_once: True for all tasks related to the native user, roles, and license API. The role can avoid unnecessary API calls as well as fixing the issue. I used the same playbook as in the issue report. The ansible log [here](http://sprunge.us/tJ6xZY) shows a successful run.

This could be further 'optimized' by delegating all the API calls to localhost. However, this would require the es_api_url to be accessible from the ansible machine which may not always be the case.