### PR TITLE
Disable gc.log logging by default

### DIFF
--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -144,7 +144,8 @@
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file={{ es_log_dir }}/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+#9-:-Xlog:gc*,gc+age=trace,safepoint:file={{ es_log_dir }}/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:disable
 {% if es_version is version('7.5.0', '<') %}
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals


### PR DESCRIPTION
Hello

I propose this modification because these logs are useless and it's annoying to maintain a jvm.options on my side only for this parameter

thank you in advance