### PR TITLE
7.9.3 release

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ provisioner:
     extra_vars:
       es_major_version: "<%= ENV['VERSION'] %>"
       <% if ENV['VERSION'] == '6.x' %>
-      es_version: '6.8.12'
+      es_version: '6.8.13'
       <% end %>
   <% end %>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * 7.9.3 as default version.
 * 6.8.13 as 6.x tested version
+
 | PR | Author | Title |
 | --- | --- | --- |
 | [#727](https://github.com/elastic/ansible-elasticsearch/pull/727) | [@smutel](https://github.com/smutel) | Add an option to not upload SSL/TLS certs  |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 7.9.3
+
+* 7.9.3 as default version.
+* 6.8.13 as 6.x tested version
+| PR | Author | Title |
+| --- | --- | --- |
+| [#727](https://github.com/elastic/ansible-elasticsearch/pull/727) | [@smutel](https://github.com/smutel) | Add an option to not upload SSL/TLS certs  |
+| [#726](https://github.com/elastic/ansible-elasticsearch/pull/726) | [@vielfarbig](https://github.com/vielfarbig) | Add note to only using es_data_dirs and es_log_dir for customizing th…  |
+
+
 ## 7.9.2 - 2020/09/24
 
 * 7.9.2 as default version

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This role uses the json_query filter which [requires jmespath](https://github.co
 Create your Ansible playbook with your own tasks, and include the role elasticsearch. You will have to have this repository accessible within the context of playbook.
 
 ```sh
-ansible-galaxy install elastic.elasticsearch,7.9.2
+ansible-galaxy install elastic.elasticsearch,7.9.3
 ```
 
 Then create your playbook yaml adding the role elasticsearch.
@@ -71,14 +71,14 @@ The simplest configuration therefore consists of:
   roles:
     - role: elastic.elasticsearch
   vars:
-    es_version: 7.9.2
+    es_version: 7.9.3
 ```
 
-The above installs Elasticsearch 7.9.2 in a single node 'node1' on the hosts 'localhost'.
+The above installs Elasticsearch 7.9.3 in a single node 'node1' on the hosts 'localhost'.
 
 **Note**:
 Elasticsearch default version is described in [`es_version`](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2). You can override this variable in your playbook to install another version.
-While we are testing this role only with one 7.x and one 6.x version (respectively [7.9.2](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2) and [6.8.12](https://github.com/elastic/ansible-elasticsearch/blob/master/.kitchen.yml#L22) at the time of writing), this role should work with other versions also in most cases.
+While we are testing this role only with one 7.x and one 6.x version (respectively [7.9.3](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2) and [6.8.13](https://github.com/elastic/ansible-elasticsearch/blob/master/.kitchen.yml#L22) at the time of writing), this role should work with other versions also in most cases.
 
 This role also uses [Ansible tags](http://docs.ansible.com/ansible/playbooks_tags.html). Run your playbook with the `--list-tasks` flag for more information.
 
@@ -401,7 +401,7 @@ In addition to es_config, the following parameters allow the customization of th
 
 * ```oss_version```  Default `false`. Setting this to `true` will install the oss release of elasticsearch
 * `es_xpack_trial` Default `false`. Setting this to `true` will start the 30-day trail once the cluster starts.
-* ```es_version``` (e.g. "7.9.2").
+* ```es_version``` (e.g. "7.9.3").
 * ```es_api_host``` The host name used for actions requiring HTTP e.g. installing templates. Defaults to "localhost".
 * ```es_api_port``` The port used for actions requiring HTTP e.g. installing templates. Defaults to 9200. **CHANGE IF THE HTTP PORT IS NOT 9200**
 * ```es_api_basic_auth_username``` The Elasticsearch username for making admin changing actions. Used if Security is enabled. Ensure this user is admin.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-es_version: "7.9.2"
+es_version: "7.9.3"
 es_use_snapshot_release: false
 oss_version: false
 es_package_name: "elasticsearch"


### PR DESCRIPTION
## 7.9.3

* 7.9.3 as default version.
* 6.8.13 as 6.x tested version

| PR | Author | Title |
| --- | --- | --- |
| [#727](https://github.com/elastic/ansible-elasticsearch/pull/727) | [@smutel](https://github.com/smutel) | Add an option to not upload SSL/TLS certs  |
| [#726](https://github.com/elastic/ansible-elasticsearch/pull/726) | [@vielfarbig](https://github.com/vielfarbig) | Add note to only using es_data_dirs and es_log_dir for customizing th…  |

