### PR TITLE
Fix java install path when system has multiple java

### DIFF
--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -13,7 +13,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: Get the installed java path
-  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0 | head -1"
+  shell: "update-alternatives --display java | grep '^/' | awk '{print $1}' | grep 1.8.0-openjdk | head -1"
   become: yes
   register: java_full_path
   failed_when: False


### PR DESCRIPTION
This commit fix the command to get Java install path when the system has
multiple java installed

Fix #721
