### PR TITLE
[meta] fix jobs template following #760

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -29,20 +29,6 @@
         url: git@github.com:elastic/ansible-elasticsearch.git
         basedir: elasticsearch
         wipe-workspace: 'False'
-    axes:
-    - axis:
-        type: slave
-        name: label
-        values:
-        - linux
-    - axis:
-        name: OS
-        filename: elasticsearch/test/matrix.yml
-        type: yaml
-    - axis:
-        name: TEST_TYPE
-        filename: elasticsearch/test/matrix.yml
-        type: yaml
     vault:
       role_id: cff5d4e0-61bf-2497-645f-fcf019d10c13
     builders:

--- a/.ci/jobs/elastic+ansible-elasticsearch+master.yml
+++ b/.ci/jobs/elastic+ansible-elasticsearch+master.yml
@@ -9,6 +9,24 @@
         default: master
         description: the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,
           &lt;commitId&gt;, etc.)
+    - string:
+        name: VERSION
+        default: 7.x
+        description: Elasticsearch major version
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: OS
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
+    - axis:
+        name: TEST_TYPE
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
     triggers:
     - timed: H H(02-04) * * *
     publishers:

--- a/.ci/jobs/elastic+ansible-elasticsearch+pull-request.yml
+++ b/.ci/jobs/elastic+ansible-elasticsearch+pull-request.yml
@@ -3,6 +3,25 @@
     name: elastic+ansible-elasticsearch+pull-request
     display-name: elastic / ansible-elasticsearch - pull-request
     description: Pull request testing with test kitchen
+    parameters:
+    - string:
+        name: VERSION
+        default: 7.x
+        description: Elasticsearch major version
+    axes:
+    - axis:
+        type: slave
+        name: label
+        values:
+        - linux
+    - axis:
+        name: OS
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
+    - axis:
+        name: TEST_TYPE
+        filename: elasticsearch/test/matrix.yml
+        type: yaml
     scm:
     - git:
         branches:


### PR DESCRIPTION
This commit fix the test job templates following #760.
- add VERSION parameter for 7.x jobs
- move axis to jobs templates
