### PR TITLE
Ad support for elasticsearch-keystore entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,26 @@ Both ```es_user_id``` and ```es_group_id``` must be set for the user and group i
 * ```es_restart_on_change``` - defaults to true.  If false, changes will not result in Elasticsearch being restarted.
 * ```es_plugins_reinstall``` - defaults to false.  If true, all currently installed plugins will be removed from a node.  Listed plugins will then be re-installed.
 
+To add, update or remove elasticsearch.keystore entries, use the following variable:
+
+```yaml
+# state is optional and defaults to present
+es_keystore_entries:
+- key: someKeyToAdd
+  value: someValue
+  state: present
+
+- key: someKeyToUpdate
+  value: newValue
+  # state: present
+  force: Yes
+
+- key: someKeyToDelete
+  state: absent
+```
+
+
+
 This role ships with sample templates located in the [test/integration/files/templates-7.x](https://github.com/elastic/ansible-elasticsearch/tree/master/test/integration/files/templates-7.x) directory. `es_templates_fileglob` variable is used with the Ansible [with_fileglob](http://docs.ansible.com/ansible/playbooks_loops.html#id4) loop. When setting the globs, be sure to use an absolute path.
 
 ### Proxy

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -34,6 +34,41 @@
     environment:
       ES_PATH_CONF: "{{ es_conf_dir }}"
     no_log: true
+
+  - name: Remove keystore entries
+    become: yes
+    command: >
+     echo {{ es_api_basic_auth_password | quote }} | {{ es_home }}/bin/elasticsearch-keystore remove '{{ item.key }}'
+    with_items: "{{ es_keystore_entries }}"
+    when:
+      - es_keystore_entries is defined and es_keystore_entries | length > 0
+      - item.state is defined and item.state == 'absent'
+      - item.key in list_keystore.stdout_lines
+      - ('bootstrap.password' not in item.key)
+    no_log: true
+
+  - name: Reload keystore entries
+    become: yes
+    command: >
+     {{es_home}}/bin/elasticsearch-keystore list
+    register: list_keystore
+    changed_when: False
+    environment:
+      ES_PATH_CONF: "{{ es_conf_dir }}"
+    check_mode: no
+
+  - name: Add keystore entries
+    become: yes
+    shell: echo {{ item.value | quote }} | {{ es_home }}/bin/elasticsearch-keystore add -x -f {{ item.key }}
+    with_items: "{{ es_keystore_entries }}"
+    when:
+      - es_keystore_entries is defined and es_keystore_entries | length > 0
+      - item.state is undefined or item.state == 'present'
+      - item.force|default(False) or ( not item.force|default(False) and item.key not in list_keystore.stdout_lines )
+      - ('bootstrap.password' not in item.key)
+    no_log: true
+
+
 ### END BLOCK elasticsearch keystore ###
 
 #-----------------------------FILE BASED REALM----------------------------------------


### PR DESCRIPTION
Add support to add, update and delete `elasticsearch.keystore` entries.

Obsoletes #685
Fix #684 