### PR TITLE
Remove OSS support for version >= 7.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Ansible-elasticsearch 7.5.2 is updating the configuration files provided by this
   - Deployment of this Ansible role on new servers will get the default `log4j2.properties` provided by Elasticsearch without any override.
   - **WARNING**: For upgrade scenarios where this file was already managed by previous versions of ansible-elasticsearch, this file will become unmanaged and won't be updated by default. If you wish to update it to 7.5 version, you can retrieve it [here](https://github.com/elastic/elasticsearch/blob/7.5/distribution/src/config/log4j2.properties) and use this file with `es_config_log4j2` Ansible variable (see below).
 
+### Removing OSS distribution for versions >= 7.11.0
+
+Starting from Elasticsearch 7.11.0, OSS distributions will no more provided following Elasticsearch
+recent license change.
+
+This Ansible role will fail if `oss_version` is set to `true` and `es_version` is greater than 
+`7.11.0`.
+
+See [Doubling down on open, Part II](https://www.elastic.co/blog/licensing-change for more details)
+blog post for more details.
+
 #### How to override configuration files provided by ansible-elasticsearch?
 
 You can now override the configuration files with your own versions by using the following Ansible variables:
@@ -128,7 +139,7 @@ $ make list
 
 The default test suite is Ubuntu 16.04 with X-Pack. If you want to test another suite you can override this with the `PATTERN` variable
 ```sh
-$ make converge PATTERN=oss-centos-7
+$ make converge PATTERN=security-centos-7
 ```
 
 The `PATTERN` is a kitchen pattern which can match multiple suites. To run all tests for CentOS
@@ -138,7 +149,7 @@ $ make converge PATTERN=centos-7
 
 The default version is 7.x. If you want to test 6.x you can override it with the `VERSION` variable, for example:
 ```sh
-$ make converge VERSION=6.x PATTERN=oss-centos-7
+$ make converge VERSION=6.x PATTERN=security-centos-7
 ```
 
 When you are finished testing you can clean up everything with
@@ -400,7 +411,7 @@ These can either be set to a user declared in the file based realm, with admin p
 
 In addition to es_config, the following parameters allow the customization of the Java and Elasticsearch versions as well as the role behavior. Options include:
 
-* ```oss_version```  Default `false`. Setting this to `true` will install the oss release of elasticsearch
+* ```oss_version```  Default `false`. Setting this to `true` will install the oss release of Elasticsearch (for version <7.11.0 only).
 * `es_xpack_trial` Default `false`. Setting this to `true` will start the 30-day trail once the cluster starts.
 * ```es_version``` (e.g. "7.10.2").
 * ```es_api_host``` The host name used for actions requiring HTTP e.g. installing templates. Defaults to "localhost".

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -5,6 +5,13 @@
     msg: "WARNING: es_xpack_features variable is now deprecated. All feature are now enabled by default"
   when: es_xpack_features is defined and not oss_version
 
+- name: "fail when oss_version is true with es_version >= 7.11.0"
+  fail:
+    msg: >
+      OSS versions are not available for Elasticsearch >= 7.11.0.
+      See https://www.elastic.co/blog/licensing-change for more details.
+  when: oss_version and es_version is version('7.11.0', '>=')
+
 - name: fail when es_proxy_port is not defined or is blank
   fail: msg="es_proxy_port must be specified and cannot be blank when es_proxy_host is defined"
   when: (es_proxy_port is not defined or es_proxy_port == '') and (es_proxy_host is defined and es_proxy_host != '')

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -12,9 +12,7 @@ TEST_TYPE:
   - custom-config
   - default
   - license
-  - oss
   - oss-to-default-upgrade
-  - oss-upgrade
   - security
   - trial
   - upgrade


### PR DESCRIPTION
This commit is removing the option to install Elasticsearch OSS
distribution for version >= 7.11.0.

This is due to Elasticsearch recent license change.
See https://www.elastic.co/blog/licensing-change for more details.

- Add notice to breaking changes and update documentation
- Fail the deployment if trying to install OSS >= 7.11.0
- Remove OSS tests for 7.x except the upgrade test from last OSS version
  to default distribution
