### PR TITLE
Fix "list native roles" task

### DIFF
--- a/tasks/xpack/security/elasticsearch-security-native.yml
+++ b/tasks/xpack/security/elasticsearch-security-native.yml
@@ -137,7 +137,6 @@
   uri:
     url: "{{ es_api_uri }}/{{ es_security_api }}/role"
     method: GET
-    body_format: json
     user: "{{es_api_basic_auth_username}}"
     password: "{{es_api_basic_auth_password}}"
     force_basic_auth: yes


### PR DESCRIPTION
This commit fix "List Native Roles" task with Elasticsearch 7.11.0+
by removing the unused [`body_format`](https://docs.ansible.com/ansible/2.9/modules/uri_module.html#parameter-body_format) parameter from `uri` module.

This parameter isn't used with a GET method but make request fail with
`request [GET /_security/role] does not support having a body` error
with Elasticsearch 7.11.0+.
