### PR TITLE
7.11.1 release

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,7 @@ provisioner:
     extra_vars:
       es_major_version: "<%= ENV['VERSION'] %>"
       <% if ENV['VERSION'] == '6.x' %>
-      es_version: '6.8.13'
+      es_version: '6.8.14'
       <% end %>
   <% end %>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.11.1
+
+* 7.11.1 as default version.
+* 6.8.14 as 6.x tested version
+
 ## 7.10.2
 
 * 7.10.2 as default version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * 7.11.1 as default version.
 * 6.8.14 as 6.x tested version
 
+| PR                                                                | Author                                                       | Title                                          |
+|-------------------------------------------------------------------|--------------------------------------------------------------|------------------------------------------------|
+| [#760](https://github.com/elastic/ansible-elasticsearch/pull/760) | [@jmlrt](https://github.com/jmlrt)                           | Add dedicated CI jobs for 6.x                  |
+| [#761](https://github.com/elastic/ansible-elasticsearch/pull/761) | [@rubarclk](https://github.com/rubarclk)                     | Fix Elasticsearch 7.x deb url                  |
+| [#769](https://github.com/elastic/ansible-elasticsearch/pull/769) | [@Bernhard-Fluehmann](https://github.com/Bernhard-Fluehmann) | Add support for elasticsearch-keystore entries |
+| [#765](https://github.com/elastic/ansible-elasticsearch/pull/765) | [@jmlrt](https://github.com/jmlrt)                           | Refactor Kitchen tests                         |
+| [#770](https://github.com/elastic/ansible-elasticsearch/pull/770) | [@jmlrt](https://github.com/jmlrt)                           | Remove OSS support for version >= 7.11.0       |
+| [#779](https://github.com/elastic/ansible-elasticsearch/pull/779) | [@jmlrt](https://github.com/jmlrt)                           | Fix "list native roles" task                   |
+
+
 ## 7.10.2
 
 * 7.10.2 as default version.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This role uses the json_query filter which [requires jmespath](https://github.co
 Create your Ansible playbook with your own tasks, and include the role elasticsearch. You will have to have this repository accessible within the context of playbook.
 
 ```sh
-ansible-galaxy install elastic.elasticsearch,v7.10.2
+ansible-galaxy install elastic.elasticsearch,v7.11.1
 ```
 
 Then create your playbook yaml adding the role elasticsearch.
@@ -83,14 +83,14 @@ The simplest configuration therefore consists of:
   roles:
     - role: elastic.elasticsearch
   vars:
-    es_version: 7.10.2
+    es_version: 7.11.1
 ```
 
-The above installs Elasticsearch 7.10.2 in a single node 'node1' on the hosts 'localhost'.
+The above installs Elasticsearch 7.11.1 in a single node 'node1' on the hosts 'localhost'.
 
 **Note**:
 Elasticsearch default version is described in [`es_version`](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2). You can override this variable in your playbook to install another version.
-While we are testing this role only with one 7.x and one 6.x version (respectively [7.10.2](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2) and [6.8.13](https://github.com/elastic/ansible-elasticsearch/blob/master/.kitchen.yml#L22) at the time of writing), this role should work with other versions also in most cases.
+While we are testing this role only with one 7.x and one 6.x version (respectively [7.11.1](https://github.com/elastic/ansible-elasticsearch/blob/master/defaults/main.yml#L2) and [6.8.14](https://github.com/elastic/ansible-elasticsearch/blob/master/.kitchen.yml#L22) at the time of writing), this role should work with other versions also in most cases.
 
 This role also uses [Ansible tags](http://docs.ansible.com/ansible/playbooks_tags.html). Run your playbook with the `--list-tasks` flag for more information.
 
@@ -413,7 +413,7 @@ In addition to es_config, the following parameters allow the customization of th
 
 * ```oss_version```  Default `false`. Setting this to `true` will install the oss release of Elasticsearch (for version <7.11.0 only).
 * `es_xpack_trial` Default `false`. Setting this to `true` will start the 30-day trail once the cluster starts.
-* ```es_version``` (e.g. "7.10.2").
+* ```es_version``` (e.g. "7.11.1").
 * ```es_api_host``` The host name used for actions requiring HTTP e.g. installing templates. Defaults to "localhost".
 * ```es_api_port``` The port used for actions requiring HTTP e.g. installing templates. Defaults to 9200. **CHANGE IF THE HTTP PORT IS NOT 9200**
 * ```es_api_basic_auth_username``` The Elasticsearch username for making admin changing actions. Used if Security is enabled. Ensure this user is admin.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-es_version: "7.10.2"
+es_version: "7.11.1"
 es_use_snapshot_release: false
 oss_version: false
 es_package_name: "elasticsearch"


### PR DESCRIPTION
## 7.11.1

* 7.11.1 as default version.
* 6.8.14 as 6.x tested version

| PR                                                                | Author                                                       | Title                                          |
|-------------------------------------------------------------------|--------------------------------------------------------------|------------------------------------------------|
| [#760](https://github.com/elastic/ansible-elasticsearch/pull/760) | [@jmlrt](https://github.com/jmlrt)                           | Add dedicated CI jobs for 6.x                  |
| [#761](https://github.com/elastic/ansible-elasticsearch/pull/761) | [@rubarclk](https://github.com/rubarclk)                     | Fix Elasticsearch 7.x deb url                  |
| [#769](https://github.com/elastic/ansible-elasticsearch/pull/769) | [@Bernhard-Fluehmann](https://github.com/Bernhard-Fluehmann) | Add support for elasticsearch-keystore entries |
| [#765](https://github.com/elastic/ansible-elasticsearch/pull/765) | [@jmlrt](https://github.com/jmlrt)                           | Refactor Kitchen tests                         |
| [#770](https://github.com/elastic/ansible-elasticsearch/pull/770) | [@jmlrt](https://github.com/jmlrt)                           | Remove OSS support for version >= 7.11.0       |
| [#779](https://github.com/elastic/ansible-elasticsearch/pull/779) | [@jmlrt](https://github.com/jmlrt)                           | Fix "list native roles" task                   |
