### PR TITLE
Stop plugin install to fail in check mode

### DIFF
--- a/tasks/elasticsearch-plugins.yml
+++ b/tasks/elasticsearch-plugins.yml
@@ -67,7 +67,7 @@
   become: yes
   command: "{{es_home}}/bin/elasticsearch-plugin install {{ item.url | default(item.plugin) }} --batch --silent"
   register: plugin_installed
-  changed_when: plugin_installed.rc == 0
+  changed_when: plugin_installed.rc|default(0) == 0
   with_items: "{{ es_plugins }}"
   when: item.plugin in plugins_to_install
   notify: restart elasticsearch
@@ -75,6 +75,6 @@
     CONF_DIR: "{{ es_conf_dir }}"
     ES_PATH_CONF: "{{ es_conf_dir }}"
     ES_INCLUDE: "{{ default_file }}"
-  until: plugin_installed.rc == 0
+  until: plugin_installed.rc|default(0) == 0
   retries: 5
   delay: 5


### PR DESCRIPTION
In check mode Ansible is actually not going to execute the command from the `Install elasticsearch plugins` task.

https://github.com/elastic/ansible-elasticsearch/blob/4f01bc74a079c726a5045bed5595273fbe2d2bc0/tasks/elasticsearch-plugins.yml#L66-L80

Thus, the `rc` parameter is not set resulting in a failed execution. My suggestion would be to default the parameter to `0`, if it is not set. This allows the role to be run in check mode as well.

## Alternative solution

Alternatively, it would be possible to add

```yml
ignore_errors: "{{ ansible_check_mode }}"
```

to the task. But I thought the submitted solution might be cleaner.

Closes #786 