### PR TITLE
Fix deb and rpm url

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -102,6 +102,10 @@
     selection: "hold"
   when: es_version_lock
 
+# workaround due to https://github.com/ansible/ansible/issues/66977
+- set_fact:
+    es_deb_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-amd64.deb{% else %}{{ es_package_url }}-{{ es_version }}.deb{% endif %}"
+
 - name: Debian - Install Elasticsearch from url
   become: yes
   apt:

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -102,13 +102,11 @@
     selection: "hold"
   when: es_version_lock
 
-- name: Debian - Download elasticsearch from url
-  get_url: url={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}-amd64.deb{% endif %} dest=/tmp/elasticsearch-{{ es_version }}.deb validate_certs=no
-  when: not es_use_repository
-
-- name: Debian - Ensure elasticsearch is installed from downloaded package
+- name: Debian - Install Elasticsearch from url
   become: yes
-  apt: deb=/tmp/elasticsearch-{{ es_version }}.deb
+  apt:
+    deb: "{% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_deb_url }}{% endif %}"
+    state: present
   when: not es_use_repository
   register: elasticsearch_install_from_package
   notify: restart elasticsearch

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -56,7 +56,9 @@
 
 - name: RedHat - Install Elasticsearch from url
   become: yes
-  yum: name={% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_package_url }}-{{ es_version }}.noarch.rpm{% endif %} state=present
+  yum:
+    name: '{% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_rpm_url }}{% endif %}'
+    state: present
   when: not es_use_repository
   register: elasticsearch_install_from_package
   notify: restart elasticsearch

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -54,6 +54,10 @@
   environment:
     ES_PATH_CONF: "{{ es_conf_dir }}"
 
+# workaround due to https://github.com/ansible/ansible/issues/66977
+- set_fact:
+    es_rpm_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-x86_64.rpm{% else %}{{ es_package_url }}-{{ es_version }}.rpm{% endif %}"
+
 - name: RedHat - Install Elasticsearch from url
   become: yes
   yum:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,4 @@ java: "{% if es_java is defined %}{{es_java}}{% else %}openjdk-{{ java_version }
 default_file: "/etc/default/elasticsearch"
 es_home: "/usr/share/elasticsearch"
 es_apt_key_id: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
+es_deb_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-amd64.deb{% else %}{{ es_package_url }}-{{ es_version }}.deb{% endif %}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,3 @@ java: "{% if es_java is defined %}{{es_java}}{% else %}openjdk-{{ java_version }
 default_file: "/etc/default/elasticsearch"
 es_home: "/usr/share/elasticsearch"
 es_apt_key_id: "46095ACC8548582C1A2699A9D27D666CD88E42B4"
-es_deb_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-amd64.deb{% else %}{{ es_package_url }}-{{ es_version }}.deb{% endif %}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,4 @@
 java: "{{ es_java | default('java-1.8.0-openjdk.x86_64') }}"
 default_file: "/etc/sysconfig/elasticsearch"
 es_home: "/usr/share/elasticsearch"
+es_rpm_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-x86_64.rpm{% else %}{{ es_package_url }}-{{ es_version }}.rpm{% endif %}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,4 +2,3 @@
 java: "{{ es_java | default('java-1.8.0-openjdk.x86_64') }}"
 default_file: "/etc/sysconfig/elasticsearch"
 es_home: "/usr/share/elasticsearch"
-es_rpm_url: "{% if es_version is version('7.0.0', '>=') %}{{ es_package_url }}-{{ es_version }}-x86_64.rpm{% else %}{{ es_package_url }}-{{ es_version }}.rpm{% endif %}"


### PR DESCRIPTION
* Fix commit fix the deb package url for Elasticsearch 6.x
* Fix commit fix the rpm package url for Elasticsearch 6.x and 7.x
* Download deb package directly using `apt` module
* Use new ansible syntax

Fix #781 