### PR TITLE
Use ES_JAVA_HOME instead of JAVA_HOME

### DIFF
--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -10,9 +10,9 @@ ES_TMPDIR={{ es_tmp_dir }}
 
 # Elasticsearch Java path
 {% if es_java_home | length > 0 %}
-JAVA_HOME={{ es_java_home }}
+ES_JAVA_HOME={{ es_java_home }}
 {% else %}
-#JAVA_HOME=
+#ES_JAVA_HOME=
 {% endif %}
 
 # Elasticsearch configuration directory


### PR DESCRIPTION
This commit set `ES_JAVA_HOME` environment variable instead of
`JAVA_HOME` when `es_java_home` environment variable is used.

See https://github.com/elastic/elasticsearch/issues/68848 for more
context.
