### PR TITLE
Fix versionlock centos 8

### DIFF
--- a/tasks/elasticsearch-RedHat-version-lock.yml
+++ b/tasks/elasticsearch-RedHat-version-lock.yml
@@ -2,13 +2,13 @@
 - name: RedHat - install yum-version-lock
   become: yes
   yum:
-    name: yum-plugin-versionlock
+    name: "{{ versionlock_plugin_package }}"
     state: present
     update_cache: yes
 
 - name: RedHat - check if requested elasticsearch version lock exists
   become: yes
-  shell: 'yum versionlock list | grep {{es_package_name}} | grep -c "{{es_version}}"'
+  shell: '{{ package_manager }} versionlock list | grep {{ es_package_name }} | grep -c "{{ es_version }}"'
   register: es_requested_version_locked
   args:
     warn: false
@@ -18,7 +18,7 @@
 
 - name: RedHat - lock elasticsearch version
   become: yes
-  shell: yum versionlock delete 0:elasticsearch* ; yum versionlock add {{ es_package_name }}-{{ es_version }}
+  command: '"{{ package_manager }}" versionlock delete 0:elasticsearch* ; "{{ package_manager }}" versionlock add {{ es_package_name }}-{{ es_version }}'
   args:
     warn: false
   when:
@@ -28,7 +28,7 @@
 
 - name: RedHat - check if any elasticsearch version lock exists
   become: yes
-  shell: yum versionlock list | grep -c elasticsearch
+  shell: '"{{ package_manager }}" versionlock list | grep -c elasticsearch'
   register: es_version_locked
   args:
     warn: false
@@ -38,7 +38,7 @@
 
 - name: RedHat - unlock elasticsearch version
   become: yes
-  shell: yum versionlock delete 0:elasticsearch*
+  shell: '"{{ package_manager }}" versionlock delete 0:elasticsearch*'
   args:
     warn: false
   when:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,5 @@
 java: "{{ es_java | default('java-1.8.0-openjdk.x86_64') }}"
 default_file: "/etc/sysconfig/elasticsearch"
 es_home: "/usr/share/elasticsearch"
+package_manager: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version >= '8' %}dnf{% else %}yum{% endif %}"
+versionlock_plugin_package: "{% if ansible_os_family == 'RedHat' and ansible_distribution_major_version >= '8' %}python3-dnf-plugin-versionlock{% else %}yum-plugin-versionlock{% endif %}"


### PR DESCRIPTION
This resolves a corner case where a RHEL/CentOS 8 system does not have the `yum` compatibility package installed - everywhere else, the role is using the `yum` ansible module which detects and uses `dnf` in recent ansible versions, so the only concern is when:

- System is RHEL/CentOS 8
- System does not have `yum` installed and only `dnf` is available to the shell module
- Role variable `es_version_lock` is set to true, invoking the `elasticsearch-RedHat-version-lock.yml` playbook.