### PR TITLE
es_custom_package_url for internal network

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -111,6 +111,7 @@
   apt:
     deb: "{% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_deb_url }}{% endif %}"
     state: present
+    validate_certs: no
   when: not es_use_repository
   register: elasticsearch_install_from_package
   notify: restart elasticsearch

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -63,6 +63,7 @@
   yum:
     name: '{% if es_custom_package_url is defined %}{{ es_custom_package_url }}{% else %}{{ es_rpm_url }}{% endif %}'
     state: present
+    disable_gpg_check: yes
   when: not es_use_repository
   register: elasticsearch_install_from_package
   notify: restart elasticsearch


### PR DESCRIPTION
Hi Team,

I am trying to install the yum package hosting on my internal network, it is a pretty normal environment; let's say some customers have no Internet for a dev testing environment. A http web server will be hosting rpm or apt packages for them for building Elasticsearch clusters.

My Ansible is on MacOS, Ansible version is 2.10.8

I am using the following playbook.

```yaml
- name: Single master elasticsearch cluster
  hosts: icaes
  roles:
    - role: elastic.elasticsearch
  vars:
    es_version: 7.13.1
    es_use_repository: false
    es_custom_package_url: "http://192.168.100.190/elasticsearch-7.13.1-x86_64.rpm"
    es_data_dirs:
      - "/opt/elasticsearch/data"
    es_log_dir: "/opt/elasticsearch/logs"
    es_config:
      node.name: "node1"
      cluster.name: "single-node"
      discovery.seed_hosts: "localhost:9301"
      http.port: 9201
      http.host: 0.0.0.0
      transport.port: 9301
      node.data: true
      node.master: true
      bootstrap.memory_lock: true
    es_heap_size: 4g
    es_api_port: 9201
```
I am trying building a stand-along elasticsearch node. I got the following error.

```sh
TASK [elastic.elasticsearch : set_fact] *********************************************
ok: [192.168.100.197]

TASK [elastic.elasticsearch : RedHat - Install Elasticsearch from url] **************
fatal: [192.168.100.197]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for elasticsearch-7.13.1-1.x86_64"}

PLAY RECAP **************************************************************************
192.168.100.197            : ok=12   changed=0    unreachable=0    failed=1    skipped=58   rescued=0    ignored=0
```
It stopped Ansbile playbook for running forward.

I made a quick fix on `/Users/martin/.ansible/roles/elastic.elasticsearch/tasks/elasticsearch-RedHat.yml`

Added `    disable_gpg_check: yes` into above file. 

Then run ansible-playbook again, it succeed with no more error.

I reviewed both source file `elasticsearch-Debian.yml` and `elasticsearch-RedHat.yml`; it seems have same problem. 

I'd like to feedback and happy to raise this pr here.

Cheers,
Martin Liu
Elastic Developer Advocate China 

