### PR TITLE
Install GPG when adding the repo on Debian systems

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -46,6 +46,11 @@
       name: apt-transport-https
       state: present
 
+  - name: Debian - Install gpg to support the requirement of apt_key in the next play
+    apt:
+      name: gpg
+      state: present
+
   - name: Debian - Add Elasticsearch repository key
     apt_key:
       url: '{{ es_apt_key }}'


### PR DESCRIPTION
By default a Debian installation does not include GPG, but it's a requirement for the apt_key module.  

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html

This PR adds a play to install it, before apt_key is called, and lets the playbook work on a freshly provisioned Debian system.