### PR TITLE
Remove Ubuntu 14.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 Ansible role for 7.x/6.x Elasticsearch.  Currently this works on Debian and RedHat based linux systems. Tested platforms are:
 
-* Ubuntu 14.04
 * Ubuntu 16.04
 * Ubuntu 18.04
 * Ubuntu 20.04

--- a/test/matrix-6x.yml
+++ b/test/matrix-6x.yml
@@ -1,5 +1,4 @@
 OS:
-  - ubuntu-1404
   - ubuntu-1604
   - ubuntu-1804
   - ubuntu-2004

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -1,5 +1,4 @@
 OS:
-  - ubuntu-1404
   - ubuntu-1604
   - ubuntu-1804
   - ubuntu-2004


### PR DESCRIPTION
This commit removes the support of Ubuntu 14.04. This distribution is
EOL since April 30th 2019 and CI tests are failing because apt
repositories aren't available anymore.
