### PR TITLE
Remove CentOS 8 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Ansible role for 7.x/6.x Elasticsearch.  Currently this works on Debian and RedH
 * Debian 9
 * Debian 10
 * CentOS 7
-* CentOS 8
 * Amazon Linux 2
 
 The latest Elasticsearch versions of 7.x & 6.x are actively tested.

--- a/test/matrix-6x.yml
+++ b/test/matrix-6x.yml
@@ -6,7 +6,6 @@ OS:
   - debian-9
   - debian-10
   - centos-7
-  - centos-8
   - amazonlinux-2
 TEST_TYPE:
   - custom-config

--- a/test/matrix.yml
+++ b/test/matrix.yml
@@ -6,7 +6,6 @@ OS:
   - debian-9
   - debian-10
   - centos-7
-  - centos-8
   - amazonlinux-2
 TEST_TYPE:
   - custom-config


### PR DESCRIPTION
This commit removes CentOS 8 tests. These tests are now failing because
CentOS 8 is now EOL and it's repositories have been archived.

Source: https://forums.centos.org/viewtopic.php?f=54&t=78708
